### PR TITLE
Fix Pages workflow when Pages isn't configured

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,15 +18,12 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      pages_enabled: ${{ steps.pages.outputs.enabled }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-        with:
-          enablement: true
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -50,12 +47,35 @@ jobs:
         run: npm run build
         working-directory: website
 
+      - name: Check Pages enabled
+        id: pages
+        uses: actions/github-script@v7
+        continue-on-error: true
+        with:
+          script: |
+            try {
+              await github.request('GET /repos/{owner}/{repo}/pages', {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+              core.setOutput('enabled', 'true');
+            } catch (error) {
+              core.setOutput('enabled', 'false');
+              core.notice('GitHub Pages is not enabled for this repo; skipping deploy.');
+            }
+
+      - name: Setup Pages
+        if: steps.pages.outputs.enabled == 'true'
+        uses: actions/configure-pages@v5
+
       - name: Upload artifact
+        if: steps.pages.outputs.enabled == 'true'
         uses: actions/upload-pages-artifact@v3
         with:
           path: website/build
 
   deploy:
+    if: needs.build.outputs.pages_enabled == 'true'
     runs-on: ubuntu-latest
     needs: build
     environment:


### PR DESCRIPTION
## Summary
- Prevent the Pages workflow from failing when GitHub Pages isn’t configured/enabled yet.
- Keep building the Docusaurus site as a smoke test, and deploy only when Pages is available.