### PR TITLE
Fix Docusaurus build: escape braces in rendered Markdown

### DIFF
--- a/packages/csif-cli/src/csif.js
+++ b/packages/csif-cli/src/csif.js
@@ -86,6 +86,9 @@ function escapeMarkdown(text) {
   return String(text)
     .replaceAll("\\", "\\\\")
     .replaceAll("|", "\\|")
+    // Docusaurus treats .md as MDX; escape braces to avoid `{...}` expressions.
+    .replaceAll("{", "&#123;")
+    .replaceAll("}", "&#125;")
     .replaceAll("\r\n", "\n")
     .replaceAll("\r", "\n")
     .replaceAll("\n", "<br/>");

--- a/website/docs/registry/git/core.md
+++ b/website/docs/registry/git/core.md
@@ -11,7 +11,7 @@ Understand repo state and history.
 
 | Cheat | Description |
 | --- | --- |
-| Working tree status | git status<br/><br/><strong>Comments</strong><br/><pre>{<br/>  "example": "git status --porcelain"<br/>}</pre> |
+| Working tree status | git status<br/><br/><strong>Comments</strong><br/><pre>&#123;<br/>  "example": "git status --porcelain"<br/>&#125;</pre> |
 | Show last commits | git log --oneline --decorate --graph --max-count 20 |
 
 ## Changes


### PR DESCRIPTION
## Summary
- Fix Docusaurus MDX build failure caused by JSON braces in rendered registry tables.
- Escape `{` and `}` in renderer output and regenerate `website/docs/registry/git/core.md`.