### PR TITLE
Fix Docusaurus baseUrl for GitHub Pages

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,10 @@
   "permissions": {
     "allow": [
       "Bash(npm run validate:*)",
-      "Bash(git add:*)"
+      "Bash(git add:*)",
+      "Bash(git checkout:*)",
+      "Bash(npm run build:*)",
+      "Bash(git commit:*)"
     ]
   }
 }

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -11,8 +11,8 @@ const config: Config = {
     v4: true,
   },
 
-  url: 'https://csif.sh',
-  baseUrl: '/',
+  url: 'https://carlesandres.github.io',
+  baseUrl: '/csif.sh/',
 
   organizationName: 'carlesandres',
   projectName: 'csif.sh',


### PR DESCRIPTION
## Summary
- Fix baseUrl configuration from `/` to `/csif.sh/` for GitHub Pages hosting at `carlesandres.github.io/csif.sh/`
- Update url to match the actual GitHub Pages domain

## Test plan
- [x] Website builds successfully with `npm run build`
- [ ] After merge, verify site loads correctly at https://carlesandres.github.io/csif.sh/

🤖 Generated with [Claude Code](https://claude.com/claude-code)