### PR TITLE
feat: complete v2 migration with direction-aware rendering and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,24 +64,35 @@ rm -rf .turbo build packages/chson-schema/types && npm run build
 
 **Key files**:
 - `packages/chson-cli/src/chson.js` - Single-file CLI with validate and render commands
-- `packages/chson-schema/schema/v1/chson.schema.json` - JSON Schema (Draft 2020-12) defining the ChSON format
-- `packages/chson-schema/types/index.d.ts` - Auto-generated TypeScript types (gitignored)
+- `packages/chson-schema/schema/v2/chson.schema.json` - JSON Schema (Draft 2020-12) defining the ChSON v2 format
+- `packages/chson-schema/schema/v1/chson.schema.json` - Legacy v1 schema (still supported)
+- `packages/chson-schema/types/` - Auto-generated TypeScript types (gitignored)
 - `packages/chson-registry/cheatsheets/` - Source cheatsheets
 - `apps/site/` - Astro website
+- `research/` - Cognitive science research supporting ChSON design
 
-**ChSON schema structure**:
+**ChSON v2 schema structure** (based on cognitive retrieval theory):
 ```
 {
-  title, version?, publicationDate, description, metadata?,
-  sections: [{ title, description?, items: [{ title, description, example?, comments? }] }]
+  title, version?, publicationDate, description, retrievalDirection?, metadata?,
+  anchorLabel?, contentLabel?,
+  sections: [{ title, description?, entries: [{ anchor, content, label?, comments? }] }]
 }
 ```
+
+Key terminology (see `research/cognitive-foundations.md`):
+- **anchor**: The retrieval anchor — what users scan for (command, shortcut, term)
+- **content**: The associated content — what users need once they find the anchor
+- **label**: Optional human-readable label when the anchor is cryptic (e.g., `gg` → "Go to start")
+- **retrievalDirection**: `"mechanism-to-meaning"` (scan by command) or `"intent-to-mechanism"` (scan by action)
+- **anchorLabel**: Custom display name for anchor column (e.g., "Example", "Shortcut")
+- **contentLabel**: Custom display name for content column (e.g., "Description", "Action")
 
 ## Workflow
 
 **Adding cheatsheets**:
 1. Create `packages/chson-registry/cheatsheets/<product>/<name>.chson.json`
-2. Include `"$schema": "https://chson.dev/schema/v1/chson.schema.json"`
+2. Include `"$schema": "https://chson.dev/schema/v2/chson.schema.json"`
 3. Run `npm run validate`
 4. Run `npm run build` to rebuild the site
 

--- a/FUTURE_IDEAS.md
+++ b/FUTURE_IDEAS.md
@@ -8,17 +8,18 @@ can iterate without losing context.
 
 - **Name**: ChSON
 - **Canonical home (assumed)**: `chson.dev`
-- **Schema URL**: `https://chson.dev/schema/v1/chson.schema.json`
+- **Schema URL**: `https://chson.dev/schema/v2/chson.schema.json` (v1 still supported)
 - **JSON Schema dialect**: Draft 2020-12
 - **Document schema pointer**: ChSON documents include a `$schema` field pointing to the canonical schema URL.
-- **Core structure**:
-  - Top-level: `title`, optional `version`, `publicationDate`, `description`, `metadata`, `sections`
-  - Section: `title`, optional `description`, `items`
-  - Item: `title`, `description`, optional `comments`
+- **Core structure (v2)** — based on cognitive retrieval theory (see `research/cognitive-foundations.md`):
+  - Top-level: `title`, optional `version`, `publicationDate`, `description`, `retrievalDirection`, `metadata`, `sections`
+  - Section: `title`, optional `description`, `entries`
+  - Entry: `anchor` (retrieval anchor), `content` (associated content), optional `label`, `comments`
+- **Retrieval direction**: `"mechanism-to-meaning"` (scan by command/syntax) or `"intent-to-mechanism"` (scan by action/intent)
 - **Keep flexibility**: allow unknown fields (`additionalProperties: true`) everywhere.
 - **Dates**: `publicationDate` accepts either `date` or `date-time`.
 - **Registry file extension**: use `.chson.json`.
-- **First renderer target**: 2-column Markdown tables (`Cheat` / `Description`).
+- **First renderer target**: 2-column Markdown tables (`Anchor` / `Content`).
 
 ## Postponed / Future Additions
 

--- a/README.md
+++ b/README.md
@@ -11,25 +11,32 @@ personal knowledge bases.
 
 A ChSON file is a single JSON document with:
 
-- top-level metadata (`title`, optional `version`, `publicationDate`, `description`)
-- optional `metadata` for custom fields
-- a `sections[]` array, each containing `items[]` (the individual cheats)
+- Top-level metadata (`title`, optional `version`, `publicationDate`, `description`)
+- Optional `retrievalDirection` ("mechanism-to-meaning" or "intent-to-mechanism")
+- Optional `anchorLabel` and `contentLabel` for custom column headers
+- Optional `metadata` for custom fields
+- A `sections[]` array, each containing `entries[]` (the individual cheats)
+- Each entry has an `anchor` (what users scan for), `content` (what they need),
+  and optional `label` (human-readable description when the anchor is cryptic)
 
 Files use the extension `.chson.json`.
 
 ## Schema
 
-ChSON files validate against the canonical JSON Schema:
+ChSON files validate against the canonical JSON Schema (currently v2):
 
-- `https://chson.dev/schema/v1/chson.schema.json`
+- `https://chson.dev/schema/v2/chson.schema.json`
 
 In each cheatsheet, set:
 
   ```json
   {
-  "$schema": "https://chson.dev/schema/v1/chson.schema.json"
+    "$schema": "https://chson.dev/schema/v2/chson.schema.json"
   }
   ```
+
+Visit the [documentation](https://chson.carlesandres.com/docs) for detailed explanations
+of anchors, content, labels, and retrieval direction.
 
 ## Quickstart
 
@@ -65,11 +72,11 @@ npm run render:build
 
 ## Registry
 
-Example cheatsheets live in the `@chson/registry` package and are showcased in the Astro website.
+Example cheatsheets live in the `@chson/registry` package and are showcased in the Next.js website.
 
 - Package: `packages/chson-registry/`
 - Example source file: `packages/chson-registry/cheatsheets/git/core.chson.json`
-- Website page: `apps/site/src/pages/cheatsheets/[product]/[name].astro`
+- Website page: `apps/site/src/app/cheatsheets/[product]/[name]/page.tsx`
 
 Generated output:
 
@@ -77,7 +84,7 @@ Generated output:
 
 ## Website
 
-The website lives in `apps/site/` (Astro).
+The website lives in `apps/site/` (Next.js).
 
 ```bash
 npm install
@@ -99,7 +106,7 @@ This is a Turborepo monorepo with the following packages:
 - `packages/chson-schema/` — ChSON JSON Schema + auto-generated TypeScript types
 - `packages/chson-registry/` — Source cheatsheets (registry)
 - `packages/chson-cli/` — CLI (`chson`) for validate + render
-- `apps/site/` — Astro website
+- `apps/site/` — Next.js website
 
 ### Package Dependencies
 
@@ -116,8 +123,13 @@ Turborepo automatically builds packages in the correct order.
 
 This repo currently ships a minimal Node CLI:
 
-- Validate ChSON files using AJV
-- Render ChSON to Markdown using 2-column tables (`Cheat` / `Description`)
+- Validate ChSON files using AJV (auto-detects v2 schema)
+- Render ChSON to Markdown using 2-column tables (Anchor / Content, with custom labels)
+
+The v2 format is based on cognitive retrieval theory. The `anchor` field represents
+what users scan for (command, shortcut, keyword), and `content` represents what they need
+(description, action, result). Optional `label` fields provide human-readable descriptions
+when anchors are cryptic. See `research/cognitive-foundations.md` for details.
 
 If you want to build a renderer (PDF, flashcards, etc.), the current schema is intentionally
 minimal — the `comments` field can hold any extra structure you need while the standard

--- a/apps/site/src/app/docs/page.tsx
+++ b/apps/site/src/app/docs/page.tsx
@@ -1,0 +1,337 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Documentation | ChSON",
+  description: "Learn about ChSON v2 format: anchors, content, labels, and cognitive-friendly cheatsheet design.",
+};
+
+function CodeBlock({ children, title }: { children: string; title?: string }) {
+  return (
+    <div className="mt-4">
+      {title && (
+        <div className="text-xs font-medium text-zinc-500 mb-1">{title}</div>
+      )}
+      <pre className="overflow-auto rounded-xl border border-black/10 bg-black/[0.04] p-4">
+        <code className="font-mono text-[13px]">{children}</code>
+      </pre>
+    </div>
+  );
+}
+
+function Section({ id, title, children }: { id: string; title: string; children: React.ReactNode }) {
+  return (
+    <section id={id} className="mt-10 first:mt-0">
+      <h2 className="text-xl font-semibold tracking-tight border-b border-black/10 pb-2">{title}</h2>
+      <div className="mt-4 space-y-4 text-zinc-700 leading-relaxed">{children}</div>
+    </section>
+  );
+}
+
+function SubSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="mt-6">
+      <h3 className="text-lg font-medium text-zinc-900">{title}</h3>
+      <div className="mt-2 space-y-3">{children}</div>
+    </div>
+  );
+}
+
+export default function DocsPage() {
+  return (
+    <article className="max-w-3xl">
+      <h1 className="font-display text-[clamp(28px,4vw,40px)] font-semibold tracking-[-0.03em]">
+        ChSON v2 Documentation
+      </h1>
+      <p className="mt-3 text-zinc-600 text-lg">
+        A JSON format for software cheatsheets, designed around how people actually look up information.
+      </p>
+
+      {/* Table of Contents */}
+      <nav className="mt-6 rounded-xl border border-black/10 bg-white/60 p-4">
+        <div className="text-sm font-medium text-zinc-500 mb-2">On this page</div>
+        <ul className="space-y-1 text-sm">
+          <li><a href="#what-is-chson" className="text-blue-700 hover:text-blue-800">What is ChSON?</a></li>
+          <li><a href="#core-concepts" className="text-blue-700 hover:text-blue-800">Core Concepts</a></li>
+          <li><a href="#advanced-features" className="text-blue-700 hover:text-blue-800">Advanced Features</a></li>
+          <li><a href="#complete-example" className="text-blue-700 hover:text-blue-800">Complete Example</a></li>
+          <li><a href="#cli-usage" className="text-blue-700 hover:text-blue-800">CLI Usage</a></li>
+          <li><a href="#best-practices" className="text-blue-700 hover:text-blue-800">Best Practices</a></li>
+        </ul>
+      </nav>
+
+      <Section id="what-is-chson" title="What is ChSON?">
+        <p>
+          ChSON (Cheatsheet JSON) is a small JSON format for writing software cheatsheets 
+          in a consistent, tool-friendly way. The goal is simple: write a cheatsheet once, 
+          then consume it anywhere—searchable websites, printable pages, study decks, or 
+          personal knowledge bases.
+        </p>
+        <p>
+          The v2 format is designed around <strong>cognitive retrieval theory</strong>: how people 
+          actually scan and look up information. When you use a cheatsheet, you typically 
+          scan for something you recognize (a command, shortcut, or keyword) to find the 
+          information you need.
+        </p>
+      </Section>
+
+      <Section id="core-concepts" title="Core Concepts">
+        <SubSection title="Anchor and Content">
+          <p>
+            Every cheatsheet entry has two key parts:
+          </p>
+          <ul className="list-disc list-inside space-y-1 ml-2">
+            <li><strong>anchor</strong> — The retrieval cue. What you scan for. (command, shortcut, keyword)</li>
+            <li><strong>content</strong> — The information you need when you find it. (description, action, result)</li>
+          </ul>
+          <p>
+            Think of it like a dictionary: you scan for the word (anchor) to find its definition (content).
+          </p>
+          <CodeBlock title="Basic entry">{`{
+  "anchor": "git status",
+  "content": "Show staged, unstaged, and untracked files."
+}`}</CodeBlock>
+        </SubSection>
+
+        <SubSection title="Optional Labels">
+          <p>
+            Sometimes the anchor is cryptic—a keyboard shortcut, obscure command, or symbol. 
+            The optional <code className="font-mono bg-black/5 px-1 rounded">label</code> field 
+            provides a human-readable description.
+          </p>
+          <CodeBlock title="Entry with label">{`{
+  "anchor": "gg",
+  "content": "Jump to visual top of history",
+  "label": "Go to start"
+}`}</CodeBlock>
+          <p>
+            Labels are useful for vim commands, keyboard shortcuts, or any anchor that 
+            isn&apos;t immediately self-explanatory.
+          </p>
+        </SubSection>
+
+        <SubSection title="Sections">
+          <p>
+            Entries are organized into sections, each with a title and optional description.
+            Sections group related entries logically—by functionality, context, or workflow.
+          </p>
+          <CodeBlock title="Section structure">{`{
+  "sections": [
+    {
+      "title": "Navigation",
+      "description": "Moving around the interface.",
+      "entries": [
+        { "anchor": "ctrl + n", "content": "Next item" },
+        { "anchor": "ctrl + p", "content": "Previous item" }
+      ]
+    }
+  ]
+}`}</CodeBlock>
+        </SubSection>
+      </Section>
+
+      <Section id="advanced-features" title="Advanced Features">
+        <SubSection title="Retrieval Direction">
+          <p>
+            The <code className="font-mono bg-black/5 px-1 rounded">retrievalDirection</code> field 
+            describes how users typically scan the cheatsheet:
+          </p>
+          <ul className="list-disc list-inside space-y-1 ml-2">
+            <li>
+              <strong>&quot;mechanism-to-meaning&quot;</strong> — Users scan by command/syntax to find what it does. 
+              Most cheatsheets work this way. <em>&quot;What does <code>git rebase -i</code> do?&quot;</em>
+            </li>
+            <li>
+              <strong>&quot;intent-to-mechanism&quot;</strong> — Users scan by goal to find how to do it. 
+              Reverse lookups. <em>&quot;How do I squash commits?&quot;</em>
+            </li>
+          </ul>
+          <CodeBlock>{`{
+  "retrievalDirection": "mechanism-to-meaning"
+}`}</CodeBlock>
+        </SubSection>
+
+        <SubSection title="Custom Column Labels">
+          <p>
+            By default, renderers display &quot;Anchor&quot; and &quot;Content&quot; as column headers. 
+            You can customize these with <code className="font-mono bg-black/5 px-1 rounded">anchorLabel</code> and{" "}
+            <code className="font-mono bg-black/5 px-1 rounded">contentLabel</code>.
+          </p>
+          <CodeBlock title="Keyboard shortcuts cheatsheet">{`{
+  "anchorLabel": "Shortcut",
+  "contentLabel": "Action"
+}`}</CodeBlock>
+          <CodeBlock title="Command reference cheatsheet">{`{
+  "anchorLabel": "Example",
+  "contentLabel": "Description"
+}`}</CodeBlock>
+          <p>
+            This makes the rendered output more intuitive for the specific type of cheatsheet.
+          </p>
+        </SubSection>
+
+        <SubSection title="Metadata">
+          <p>
+            The optional <code className="font-mono bg-black/5 px-1 rounded">metadata</code> field 
+            holds custom key-value pairs for tooling, categorization, or attribution.
+          </p>
+          <CodeBlock>{`{
+  "metadata": {
+    "homepage": "https://atuin.sh/",
+    "category": "cli",
+    "author": "Your Name"
+  }
+}`}</CodeBlock>
+        </SubSection>
+      </Section>
+
+      <Section id="complete-example" title="Complete Example">
+        <p>
+          Here&apos;s a real-world example: an{" "}
+          <Link href="/cheatsheets/atuin/keybindings" className="text-blue-700 hover:text-blue-800">
+            Atuin keybindings cheatsheet
+          </Link>{" "}
+          demonstrating the v2 format with custom labels, section descriptions, and cryptic 
+          shortcuts that benefit from human-readable labels.
+        </p>
+        <CodeBlock>{`{
+  "$schema": "https://chson.dev/schema/v2/chson.schema.json",
+  "title": "Atuin Keybindings",
+  "version": "18.x",
+  "publicationDate": "2026-02-15",
+  "description": "Keyboard shortcuts for Atuin's interactive shell history search UI.",
+  "retrievalDirection": "mechanism-to-meaning",
+  "anchorLabel": "Shortcut",
+  "contentLabel": "Action",
+  "metadata": {
+    "homepage": "https://atuin.sh/",
+    "category": "cli"
+  },
+  "sections": [
+    {
+      "title": "Navigation & Selection",
+      "entries": [
+        {
+          "anchor": "enter",
+          "content": "Execute selected item"
+        },
+        {
+          "anchor": "ctrl + c / ctrl + d / ctrl + g / esc",
+          "content": "Cancel search and return to shell",
+          "label": "Cancel"
+        },
+        {
+          "anchor": "alt + 1 to alt + 9",
+          "content": "Select item by number shown next to it",
+          "label": "Quick select"
+        }
+      ]
+    },
+    {
+      "title": "Vim Mode - Scrolling",
+      "description": "Normal mode scrolling commands.",
+      "entries": [
+        {
+          "anchor": "gg",
+          "content": "Jump to visual top of history",
+          "label": "Go to start"
+        },
+        {
+          "anchor": "G",
+          "content": "Jump to visual bottom of history"
+        }
+      ]
+    }
+  ]
+}`}</CodeBlock>
+        <p className="mt-4">
+          <Link 
+            href="/cheatsheets/atuin/keybindings" 
+            className="text-blue-700 hover:text-blue-800 font-medium"
+          >
+            View the full Atuin cheatsheet →
+          </Link>
+        </p>
+      </Section>
+
+      <Section id="cli-usage" title="CLI Usage">
+        <p>
+          The ChSON CLI validates files against the schema and renders them to Markdown.
+        </p>
+
+        <SubSection title="Validate a cheatsheet">
+          <CodeBlock>{`node packages/chson-cli/src/chson.js validate path/to/file.chson.json`}</CodeBlock>
+          <p>
+            Validates against the v2 schema (auto-detected from the <code className="font-mono bg-black/5 px-1 rounded">$schema</code> field).
+          </p>
+        </SubSection>
+
+        <SubSection title="Render to Markdown">
+          <CodeBlock>{`node packages/chson-cli/src/chson.js render markdown path/to/file.chson.json`}</CodeBlock>
+          <p>
+            Outputs a 2-column Markdown table using the cheatsheet&apos;s column labels.
+          </p>
+        </SubSection>
+
+        <SubSection title="Validate all cheatsheets">
+          <CodeBlock>{`npm run validate`}</CodeBlock>
+        </SubSection>
+      </Section>
+
+      <Section id="best-practices" title="Best Practices">
+        <SubSection title="When to use labels">
+          <ul className="list-disc list-inside space-y-1 ml-2">
+            <li>Keyboard shortcuts (<code className="font-mono bg-black/5 px-1 rounded">ctrl + shift + p</code>)</li>
+            <li>Vim/editor commands (<code className="font-mono bg-black/5 px-1 rounded">gg</code>, <code className="font-mono bg-black/5 px-1 rounded">dd</code>)</li>
+            <li>Abbreviated commands (<code className="font-mono bg-black/5 px-1 rounded">git stash pop</code> might need context)</li>
+            <li>Any anchor that isn&apos;t immediately clear to your target audience</li>
+          </ul>
+        </SubSection>
+
+        <SubSection title="Choosing retrieval direction">
+          <ul className="list-disc list-inside space-y-1 ml-2">
+            <li>Use <strong>&quot;mechanism-to-meaning&quot;</strong> for most cheatsheets (command references, shortcuts)</li>
+            <li>Use <strong>&quot;intent-to-mechanism&quot;</strong> when users will search by goal (&quot;how do I...&quot;)</li>
+            <li>When unsure, default to &quot;mechanism-to-meaning&quot;</li>
+          </ul>
+        </SubSection>
+
+        <SubSection title="Structuring sections">
+          <ul className="list-disc list-inside space-y-1 ml-2">
+            <li>Group by functionality, not alphabetically</li>
+            <li>Put the most common operations first</li>
+            <li>Use section descriptions to provide context when needed</li>
+            <li>Keep sections focused—split large sections into smaller ones</li>
+          </ul>
+        </SubSection>
+
+        <SubSection title="Column label conventions">
+          <ul className="list-disc list-inside space-y-1 ml-2">
+            <li>Keyboard shortcuts: &quot;Shortcut&quot; / &quot;Action&quot;</li>
+            <li>CLI commands: &quot;Command&quot; or &quot;Example&quot; / &quot;Description&quot;</li>
+            <li>Configuration: &quot;Option&quot; / &quot;Description&quot; or &quot;Default&quot;</li>
+            <li>Glossaries: &quot;Term&quot; / &quot;Definition&quot;</li>
+          </ul>
+        </SubSection>
+      </Section>
+
+      <div className="mt-12 pt-8 border-t border-black/10">
+        <p className="text-sm text-zinc-500">
+          Schema URL:{" "}
+          <code className="font-mono bg-black/5 px-1 rounded">
+            https://chson.dev/schema/v2/chson.schema.json
+          </code>
+        </p>
+        <p className="mt-2 text-sm text-zinc-500">
+          For the full schema, see{" "}
+          <a 
+            href="https://github.com/carlesandres/csif.sh/blob/main/packages/chson-schema/schema/v2/chson.schema.json"
+            className="text-blue-700 hover:text-blue-800"
+          >
+            the schema on GitHub
+          </a>.
+        </p>
+      </div>
+    </article>
+  );
+}

--- a/apps/site/src/app/layout.tsx
+++ b/apps/site/src/app/layout.tsx
@@ -26,6 +26,12 @@ function Header() {
           </Link>
           <Link
             className="rounded-xl px-3 py-2 text-sm text-zinc-600 hover:bg-black/5 hover:text-zinc-900 hover:no-underline"
+            href="/docs"
+          >
+            Docs
+          </Link>
+          <Link
+            className="rounded-xl px-3 py-2 text-sm text-zinc-600 hover:bg-black/5 hover:text-zinc-900 hover:no-underline"
             href="/cheatsheets"
           >
             Cheatsheets

--- a/apps/site/src/app/page.tsx
+++ b/apps/site/src/app/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { getAllCheatsheets } from "@/lib/cheatsheets";
 
-const schemaUrl = "https://chson.dev/schema/v1/chson.schema.json";
+const schemaUrl = "https://chson.dev/schema/v2/chson.schema.json";
 
 export default function Home() {
   const sheets = getAllCheatsheets().slice(0, 4);
@@ -28,11 +28,10 @@ export default function Home() {
   "sections": [
     {
       "title": "Basics",
-      "items": [
+      "entries": [
         {
-          "title": "Check status",
-          "example": "git status",
-          "description": "Show working tree status."
+          "anchor": "git status",
+          "content": "Show working tree status."
         }
       ]
     }
@@ -40,7 +39,10 @@ export default function Home() {
 }`}</code>
           </pre>
           <p className="mt-2 text-xs text-zinc-600">
-            Add <code className="font-mono">$schema</code> for editor autocompletion and validation.
+            Add <code className="font-mono">$schema</code> for editor autocompletion.{" "}
+            <Link href="/docs" className="text-blue-700 hover:text-blue-800">
+              Learn more →
+            </Link>
           </p>
         </div>
 

--- a/initial-ideas.md
+++ b/initial-ideas.md
@@ -13,6 +13,8 @@ present, enhance and create those cheatsheets.
 
 - Bring the vocabulary of neuroscience and learning to cheatsheets and
 evangelise why cheatsheets are a great way to learn software
+  - See [research/cognitive-foundations.md](./research/cognitive-foundations.md)
+    for theoretical framework
 
 
 

--- a/packages/chson-registry/README.md
+++ b/packages/chson-registry/README.md
@@ -10,7 +10,7 @@ cheatsheets/
 │   └── <name>.chson.json
 ```
 
-Each cheatsheet validates against `@chson/schema/v1`.
+Each cheatsheet validates against `@chson/schema/v2`.
 
 ## Available Tasks
 
@@ -21,5 +21,5 @@ Each cheatsheet validates against `@chson/schema/v1`.
 ## Adding Cheatsheets
 
 1. Create `cheatsheets/<product>/<name>.chson.json`
-2. Include `"$schema": "https://chson.dev/schema/v1/chson.schema.json"` for IDE support
+2. Include `"$schema": "https://chson.dev/schema/v2/chson.schema.json"` for IDE support
 3. Run `npm run validate` to ensure it's valid

--- a/packages/chson-registry/cheatsheets/atuin/keybindings.chson.json
+++ b/packages/chson-registry/cheatsheets/atuin/keybindings.chson.json
@@ -1,0 +1,293 @@
+{
+  "$schema": "https://chson.dev/schema/v2/chson.schema.json",
+  "title": "Atuin Keybindings",
+  "version": "18.x",
+  "publicationDate": "2026-02-15",
+  "description": "Keyboard shortcuts for Atuin's interactive shell history search UI.",
+  "retrievalDirection": "intent-to-mechanism",
+  "anchorLabel": "Action",
+  "contentLabel": "Shortcut",
+  "metadata": {
+    "homepage": "https://atuin.sh/",
+    "docs": "https://docs.atuin.sh/cli/configuration/key-binding/",
+    "category": "cli"
+  },
+  "sections": [
+    {
+      "title": "Navigation & Selection",
+      "entries": [
+        {
+          "anchor": "Execute selected item",
+          "content": "enter"
+        },
+        {
+          "anchor": "Select item and edit before executing",
+          "content": "tab"
+        },
+        {
+          "anchor": "Cancel search and return to shell",
+          "content": "ctrl + c / ctrl + d / ctrl + g / esc"
+        },
+        {
+          "anchor": "Select next item",
+          "content": "ctrl + n / ctrl + j / ↑"
+        },
+        {
+          "anchor": "Select previous item",
+          "content": "ctrl + p / ctrl + k / ↓"
+        },
+        {
+          "anchor": "Quick select item by number",
+          "content": "alt + 1 to alt + 9"
+        },
+        {
+          "anchor": "Scroll results one page down",
+          "content": "page down"
+        },
+        {
+          "anchor": "Scroll results one page up",
+          "content": "page up"
+        }
+      ]
+    },
+    {
+      "title": "Search & Filters",
+      "entries": [
+        {
+          "anchor": "Cycle through filter modes (global, host, session, directory)",
+          "content": "ctrl + r"
+        },
+        {
+          "anchor": "Cycle through search modes (fuzzy, prefix, full-text)",
+          "content": "ctrl + s"
+        },
+        {
+          "anchor": "Switch to context of selected command / return to default",
+          "content": "ctrl + a, c"
+        }
+      ]
+    },
+    {
+      "title": "Text Editing",
+      "entries": [
+        {
+          "anchor": "Move cursor to previous word",
+          "content": "ctrl + ← / alt + b"
+        },
+        {
+          "anchor": "Move cursor to next word",
+          "content": "ctrl + → / alt + f"
+        },
+        {
+          "anchor": "Move cursor left one character",
+          "content": "ctrl + b / ←"
+        },
+        {
+          "anchor": "Move cursor right one character",
+          "content": "ctrl + f / →"
+        },
+        {
+          "anchor": "Move cursor to start of line",
+          "content": "ctrl + a / home"
+        },
+        {
+          "anchor": "Move cursor to end of line",
+          "content": "ctrl + e / end"
+        },
+        {
+          "anchor": "Delete previous word",
+          "content": "ctrl + backspace"
+        },
+        {
+          "anchor": "Delete next word",
+          "content": "ctrl + delete"
+        },
+        {
+          "anchor": "Delete word before cursor (across word boundaries)",
+          "content": "ctrl + w"
+        },
+        {
+          "anchor": "Clear the entire line",
+          "content": "ctrl + u"
+        }
+      ]
+    },
+    {
+      "title": "Clipboard & Inspector",
+      "entries": [
+        {
+          "anchor": "Copy selected item to clipboard",
+          "content": "ctrl + y"
+        },
+        {
+          "anchor": "Open the inspector for detailed view",
+          "content": "ctrl + o"
+        }
+      ]
+    },
+    {
+      "title": "Inspector Mode",
+      "description": "Shortcuts available when the inspector is open (ctrl + o).",
+      "entries": [
+        {
+          "anchor": "Close inspector, return to shell",
+          "content": "esc"
+        },
+        {
+          "anchor": "Close inspector, return to search view",
+          "content": "ctrl + o"
+        },
+        {
+          "anchor": "Delete inspected item from history",
+          "content": "ctrl + d"
+        },
+        {
+          "anchor": "Inspect previous item",
+          "content": "↑ / page up"
+        },
+        {
+          "anchor": "Inspect next item",
+          "content": "↓ / page down"
+        },
+        {
+          "anchor": "Execute selected item",
+          "content": "enter"
+        },
+        {
+          "anchor": "Select item and edit",
+          "content": "tab"
+        }
+      ]
+    },
+    {
+      "title": "Vim Mode - Navigation",
+      "description": "Available when vim mode is enabled in config. Normal mode.",
+      "entries": [
+        {
+          "anchor": "Select next item",
+          "content": "k"
+        },
+        {
+          "anchor": "Select previous item",
+          "content": "j"
+        },
+        {
+          "anchor": "Move cursor left",
+          "content": "h"
+        },
+        {
+          "anchor": "Move cursor right",
+          "content": "l"
+        },
+        {
+          "anchor": "Move cursor to next word",
+          "content": "w"
+        },
+        {
+          "anchor": "Move cursor to previous word",
+          "content": "b"
+        },
+        {
+          "anchor": "Move cursor to end of current/next word",
+          "content": "e"
+        },
+        {
+          "anchor": "Move cursor to start of line",
+          "content": "0"
+        },
+        {
+          "anchor": "Move cursor to end of line",
+          "content": "$"
+        }
+      ]
+    },
+    {
+      "title": "Vim Mode - Scrolling",
+      "description": "Normal mode scrolling commands.",
+      "entries": [
+        {
+          "anchor": "Half-page up (toward visual top)",
+          "content": "ctrl + u"
+        },
+        {
+          "anchor": "Half-page down (toward visual bottom)",
+          "content": "ctrl + d"
+        },
+        {
+          "anchor": "Full-page up",
+          "content": "ctrl + b"
+        },
+        {
+          "anchor": "Full-page down",
+          "content": "ctrl + f"
+        },
+        {
+          "anchor": "Jump to visual bottom of history",
+          "content": "G"
+        },
+        {
+          "anchor": "Jump to visual top of history",
+          "content": "gg"
+        },
+        {
+          "anchor": "Jump to top of visible screen",
+          "content": "H"
+        },
+        {
+          "anchor": "Jump to middle of visible screen",
+          "content": "M"
+        },
+        {
+          "anchor": "Jump to bottom of visible screen",
+          "content": "L"
+        }
+      ]
+    },
+    {
+      "title": "Vim Mode - Editing",
+      "description": "Normal mode editing commands.",
+      "entries": [
+        {
+          "anchor": "Delete character under cursor",
+          "content": "x"
+        },
+        {
+          "anchor": "Clear entire line",
+          "content": "dd"
+        },
+        {
+          "anchor": "Delete to end of line",
+          "content": "D"
+        },
+        {
+          "anchor": "Delete to end of line and enter insert mode",
+          "content": "C"
+        },
+        {
+          "anchor": "Enter insert mode",
+          "content": "i"
+        },
+        {
+          "anchor": "Move to start of line and enter insert mode",
+          "content": "I"
+        },
+        {
+          "anchor": "Move right and enter insert mode",
+          "content": "a"
+        },
+        {
+          "anchor": "Move to end of line and enter insert mode",
+          "content": "A"
+        },
+        {
+          "anchor": "Clear input and enter insert mode (search)",
+          "content": "? / /"
+        },
+        {
+          "anchor": "Exit insert mode, enter normal mode",
+          "content": "esc"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/chson-registry/cheatsheets/docker/core.chson.json
+++ b/packages/chson-registry/cheatsheets/docker/core.chson.json
@@ -1,9 +1,12 @@
 {
-  "$schema": "https://chson.dev/schema/v1/chson.schema.json",
+  "$schema": "https://chson.dev/schema/v2/chson.schema.json",
   "title": "Docker Essentials",
   "version": "24.x",
   "publicationDate": "2026-01-16",
   "description": "Essential Docker commands for container management.",
+  "retrievalDirection": "mechanism-to-meaning",
+  "anchorLabel": "Example",
+  "contentLabel": "Description",
   "metadata": {
     "homepage": "https://docs.docker.com/",
     "category": "cli"
@@ -11,156 +14,132 @@
   "sections": [
     {
       "title": "Images",
-      "items": [
+      "entries": [
         {
-          "title": "Pull image",
-          "example": "docker pull nginx:latest",
-          "description": "Download an image from a registry."
+          "anchor": "docker pull <image>:<tag>",
+          "content": "Download an image from a registry."
         },
         {
-          "title": "List images",
-          "example": "docker images",
-          "description": "Show all local images."
+          "anchor": "docker images",
+          "content": "Show all local images."
         },
         {
-          "title": "Build image",
-          "example": "docker build -t myapp:1.0 .",
-          "description": "Build image from Dockerfile in current directory."
+          "anchor": "docker build -t <name>:<tag> .",
+          "content": "Build image from Dockerfile in current directory."
         },
         {
-          "title": "Remove image",
-          "example": "docker rmi nginx:latest",
-          "description": "Delete a local image."
+          "anchor": "docker rmi <image>",
+          "content": "Delete a local image."
         },
         {
-          "title": "Prune unused",
-          "example": "docker image prune -a",
-          "description": "Remove all unused images."
+          "anchor": "docker image prune -a",
+          "content": "Remove all unused images."
         }
       ]
     },
     {
       "title": "Containers",
-      "items": [
+      "entries": [
         {
-          "title": "Run",
-          "example": "docker run -d -p 8080:80 nginx",
-          "description": "Start a container in detached mode with port mapping."
+          "anchor": "docker run -d -p <host>:<container> <image>",
+          "content": "Start a container in detached mode with port mapping."
         },
         {
-          "title": "List running",
-          "example": "docker ps",
-          "description": "Show running containers."
+          "anchor": "docker ps",
+          "content": "Show running containers."
         },
         {
-          "title": "List all",
-          "example": "docker ps -a",
-          "description": "Show all containers including stopped."
+          "anchor": "docker ps -a",
+          "content": "Show all containers including stopped."
         },
         {
-          "title": "Stop",
-          "example": "docker stop my-container",
-          "description": "Gracefully stop a running container."
+          "anchor": "docker stop <container>",
+          "content": "Gracefully stop a running container."
         },
         {
-          "title": "Remove",
-          "example": "docker rm my-container",
-          "description": "Delete a stopped container."
+          "anchor": "docker rm <container>",
+          "content": "Delete a stopped container."
         },
         {
-          "title": "Logs",
-          "example": "docker logs -f my-container",
-          "description": "Follow container logs in real-time."
+          "anchor": "docker logs -f <container>",
+          "content": "Follow container logs in real-time."
         }
       ]
     },
     {
       "title": "Exec & Debug",
-      "items": [
+      "entries": [
         {
-          "title": "Shell into container",
-          "example": "docker exec -it my-container /bin/sh",
-          "description": "Open interactive shell in running container."
+          "anchor": "docker exec -it <container> /bin/sh",
+          "content": "Open interactive shell in running container."
         },
         {
-          "title": "Run command",
-          "example": "docker exec my-container cat /etc/hosts",
-          "description": "Execute a command in a running container."
+          "anchor": "docker exec <container> <command>",
+          "content": "Execute a command in a running container."
         },
         {
-          "title": "Inspect",
-          "example": "docker inspect my-container",
-          "description": "View detailed container configuration as JSON."
+          "anchor": "docker inspect <container>",
+          "content": "View detailed container configuration as JSON."
         },
         {
-          "title": "Stats",
-          "example": "docker stats",
-          "description": "Live resource usage for all containers."
+          "anchor": "docker stats",
+          "content": "Live resource usage for all containers."
         }
       ]
     },
     {
       "title": "Volumes",
-      "items": [
+      "entries": [
         {
-          "title": "Create volume",
-          "example": "docker volume create mydata",
-          "description": "Create a named volume for persistent data."
+          "anchor": "docker volume create <name>",
+          "content": "Create a named volume for persistent data."
         },
         {
-          "title": "List volumes",
-          "example": "docker volume ls",
-          "description": "Show all volumes."
+          "anchor": "docker volume ls",
+          "content": "Show all volumes."
         },
         {
-          "title": "Mount volume",
-          "example": "docker run -v mydata:/app/data nginx",
-          "description": "Attach a volume to a container."
+          "anchor": "docker run -v <volume>:<path> <image>",
+          "content": "Attach a volume to a container."
         },
         {
-          "title": "Bind mount",
-          "example": "docker run -v $(pwd):/app nginx",
-          "description": "Mount host directory into container."
+          "anchor": "docker run -v $(pwd):<path> <image>",
+          "content": "Mount host directory into container.",
+          "label": "Bind mount"
         }
       ]
     },
     {
       "title": "Networks",
-      "items": [
+      "entries": [
         {
-          "title": "List networks",
-          "example": "docker network ls",
-          "description": "Show all Docker networks."
+          "anchor": "docker network ls",
+          "content": "Show all Docker networks."
         },
         {
-          "title": "Create network",
-          "example": "docker network create mynet",
-          "description": "Create a custom bridge network."
+          "anchor": "docker network create <name>",
+          "content": "Create a custom bridge network."
         },
         {
-          "title": "Connect container",
-          "example": "docker network connect mynet my-container",
-          "description": "Add a container to a network."
+          "anchor": "docker network connect <network> <container>",
+          "content": "Add a container to a network."
         }
       ]
     },
     {
       "title": "Cleanup",
-      "items": [
+      "entries": [
         {
-          "title": "Remove stopped containers",
-          "example": "docker container prune",
-          "description": "Delete all stopped containers."
+          "anchor": "docker container prune",
+          "content": "Delete all stopped containers."
         },
         {
-          "title": "System prune",
-          "example": "docker system prune -a --volumes",
-          "description": "Remove all unused data (images, containers, volumes)."
+          "anchor": "docker system prune -a --volumes",
+          "content": "Remove all unused data (images, containers, volumes)."
         },
         {
-          "title": "Disk usage",
-          "example": "docker system df",
-          "description": "Show Docker disk usage summary."
+          "anchor": "docker system df",
+          "content": "Show Docker disk usage summary."
         }
       ]
     }

--- a/packages/chson-registry/cheatsheets/git/core.chson.json
+++ b/packages/chson-registry/cheatsheets/git/core.chson.json
@@ -1,9 +1,12 @@
 {
-  "$schema": "https://chson.dev/schema/v1/chson.schema.json",
+  "$schema": "https://chson.dev/schema/v2/chson.schema.json",
   "title": "Git Essentials",
   "version": "2.x",
   "publicationDate": "2026-01-16",
   "description": "Essential git commands for day-to-day development.",
+  "retrievalDirection": "mechanism-to-meaning",
+  "anchorLabel": "Example",
+  "contentLabel": "Description",
   "metadata": {
     "homepage": "https://git-scm.com/",
     "category": "cli"
@@ -11,191 +14,163 @@
   "sections": [
     {
       "title": "Setup",
-      "items": [
+      "entries": [
         {
-          "title": "Set identity",
-          "example": "git config --global user.name \"Your Name\"",
-          "description": "Configure your name for commits (also set user.email)."
+          "anchor": "git config --global user.name \"Your Name\"",
+          "content": "Configure your name for commits (also set user.email).",
+          "label": "Set identity"
         },
         {
-          "title": "Set default branch",
-          "example": "git config --global init.defaultBranch main",
-          "description": "Use 'main' as the default branch for new repos."
+          "anchor": "git config --global init.defaultBranch main",
+          "content": "Use 'main' as the default branch for new repos.",
+          "label": "Set default branch"
         }
       ]
     },
     {
       "title": "Inspect",
-      "items": [
+      "entries": [
         {
-          "title": "Status",
-          "example": "git status",
-          "description": "Show staged, unstaged, and untracked files."
+          "anchor": "git status",
+          "content": "Show staged, unstaged, and untracked files."
         },
         {
-          "title": "Log",
-          "example": "git log --oneline --graph -10",
-          "description": "View recent commit history in compact format."
+          "anchor": "git log --oneline --graph -10",
+          "content": "View recent commit history in compact format."
         },
         {
-          "title": "Diff",
-          "example": "git diff --staged",
-          "description": "Show changes staged for the next commit."
+          "anchor": "git diff --staged",
+          "content": "Show changes staged for the next commit."
         },
         {
-          "title": "Blame",
-          "example": "git blame path/to/file.ext",
-          "description": "Show who last modified each line of a file."
+          "anchor": "git blame <file>",
+          "content": "Show who last modified each line of a file."
         }
       ]
     },
     {
       "title": "Stage & Commit",
-      "items": [
+      "entries": [
         {
-          "title": "Stage all",
-          "example": "git add .",
-          "description": "Stage all changes in current directory."
+          "anchor": "git add .",
+          "content": "Stage all changes in current directory."
         },
         {
-          "title": "Stage interactively",
-          "example": "git add -p",
-          "description": "Stage changes hunk by hunk."
+          "anchor": "git add -p",
+          "content": "Stage changes hunk by hunk."
         },
         {
-          "title": "Unstage",
-          "example": "git restore --staged file.ext",
-          "description": "Remove file from staging area, keep changes."
+          "anchor": "git restore --staged <file>",
+          "content": "Remove file from staging area, keep changes."
         },
         {
-          "title": "Commit",
-          "example": "git commit -m \"Add feature\"",
-          "description": "Create a commit with staged changes."
+          "anchor": "git commit -m \"<message>\"",
+          "content": "Create a commit with staged changes."
         },
         {
-          "title": "Amend",
-          "example": "git commit --amend",
-          "description": "Modify the last commit (message or content)."
+          "anchor": "git commit --amend",
+          "content": "Modify the last commit (message or content)."
         }
       ]
     },
     {
       "title": "Branches",
-      "items": [
+      "entries": [
         {
-          "title": "Create & switch",
-          "example": "git switch -c feature/new-thing",
-          "description": "Create a new branch and switch to it."
+          "anchor": "git switch -c <branch>",
+          "content": "Create a new branch and switch to it."
         },
         {
-          "title": "Switch",
-          "example": "git switch main",
-          "description": "Switch to an existing branch."
+          "anchor": "git switch <branch>",
+          "content": "Switch to an existing branch."
         },
         {
-          "title": "List",
-          "example": "git branch -vv",
-          "description": "List branches with upstream tracking info."
+          "anchor": "git branch -vv",
+          "content": "List branches with upstream tracking info."
         },
         {
-          "title": "Delete",
-          "example": "git branch -d feature/done",
-          "description": "Delete a merged branch (-D to force)."
+          "anchor": "git branch -d <branch>",
+          "content": "Delete a merged branch (-D to force)."
         }
       ]
     },
     {
       "title": "Remote",
-      "items": [
+      "entries": [
         {
-          "title": "Clone",
-          "example": "git clone git@github.com:org/repo.git",
-          "description": "Download a repository and its history."
+          "anchor": "git clone <url>",
+          "content": "Download a repository and its history."
         },
         {
-          "title": "Fetch",
-          "example": "git fetch --prune",
-          "description": "Download refs and clean up deleted remote branches."
+          "anchor": "git fetch --prune",
+          "content": "Download refs and clean up deleted remote branches."
         },
         {
-          "title": "Pull",
-          "example": "git pull --rebase",
-          "description": "Fetch and rebase local commits on top."
+          "anchor": "git pull --rebase",
+          "content": "Fetch and rebase local commits on top."
         },
         {
-          "title": "Push",
-          "example": "git push -u origin feature/branch",
-          "description": "Push branch and set upstream tracking."
+          "anchor": "git push -u origin <branch>",
+          "content": "Push branch and set upstream tracking."
         }
       ]
     },
     {
       "title": "Merge & Rebase",
-      "items": [
+      "entries": [
         {
-          "title": "Merge",
-          "example": "git merge feature/branch",
-          "description": "Merge another branch into current branch."
+          "anchor": "git merge <branch>",
+          "content": "Merge another branch into current branch."
         },
         {
-          "title": "Rebase",
-          "example": "git rebase origin/main",
-          "description": "Replay commits on top of another base."
+          "anchor": "git rebase <base>",
+          "content": "Replay commits on top of another base."
         },
         {
-          "title": "Continue rebase",
-          "example": "git rebase --continue",
-          "description": "Continue after resolving conflicts."
+          "anchor": "git rebase --continue",
+          "content": "Continue after resolving conflicts."
         },
         {
-          "title": "Cherry-pick",
-          "example": "git cherry-pick abc123",
-          "description": "Apply a specific commit to current branch."
+          "anchor": "git cherry-pick <commit>",
+          "content": "Apply a specific commit to current branch."
         }
       ]
     },
     {
       "title": "Stash",
-      "items": [
+      "entries": [
         {
-          "title": "Save",
-          "example": "git stash push -m \"wip\"",
-          "description": "Temporarily save uncommitted changes."
+          "anchor": "git stash push -m \"<message>\"",
+          "content": "Temporarily save uncommitted changes."
         },
         {
-          "title": "List",
-          "example": "git stash list",
-          "description": "Show all stashed changes."
+          "anchor": "git stash list",
+          "content": "Show all stashed changes."
         },
         {
-          "title": "Apply",
-          "example": "git stash pop",
-          "description": "Restore and remove most recent stash."
+          "anchor": "git stash pop",
+          "content": "Restore and remove most recent stash."
         }
       ]
     },
     {
       "title": "Undo",
-      "items": [
+      "entries": [
         {
-          "title": "Discard changes",
-          "example": "git restore file.ext",
-          "description": "Discard working tree changes to a file."
+          "anchor": "git restore <file>",
+          "content": "Discard working tree changes to a file."
         },
         {
-          "title": "Revert commit",
-          "example": "git revert HEAD",
-          "description": "Create a new commit that undoes a previous one."
+          "anchor": "git revert HEAD",
+          "content": "Create a new commit that undoes a previous one."
         },
         {
-          "title": "Reset soft",
-          "example": "git reset --soft HEAD~1",
-          "description": "Undo last commit, keep changes staged."
+          "anchor": "git reset --soft HEAD~1",
+          "content": "Undo last commit, keep changes staged."
         },
         {
-          "title": "Reflog",
-          "example": "git reflog",
-          "description": "Show history of HEAD movements for recovery."
+          "anchor": "git reflog",
+          "content": "Show history of HEAD movements for recovery."
         }
       ]
     }

--- a/packages/chson-registry/cheatsheets/npm/core.chson.json
+++ b/packages/chson-registry/cheatsheets/npm/core.chson.json
@@ -1,9 +1,12 @@
 {
-  "$schema": "https://chson.dev/schema/v1/chson.schema.json",
+  "$schema": "https://chson.dev/schema/v2/chson.schema.json",
   "title": "npm Essentials",
   "version": "10.x",
   "publicationDate": "2026-01-16",
   "description": "Essential npm commands for Node.js package management.",
+  "retrievalDirection": "mechanism-to-meaning",
+  "anchorLabel": "Example",
+  "contentLabel": "Description",
   "metadata": {
     "homepage": "https://docs.npmjs.com/",
     "category": "cli"
@@ -11,141 +14,120 @@
   "sections": [
     {
       "title": "Project Setup",
-      "items": [
+      "entries": [
         {
-          "title": "Initialize project",
-          "example": "npm init -y",
-          "description": "Create package.json with defaults."
+          "anchor": "npm init -y",
+          "content": "Create package.json with defaults."
         },
         {
-          "title": "Install dependencies",
-          "example": "npm install",
-          "description": "Install all dependencies from package.json."
+          "anchor": "npm install",
+          "content": "Install all dependencies from package.json."
         },
         {
-          "title": "Clean install",
-          "example": "npm ci",
-          "description": "Install exact versions from package-lock.json."
+          "anchor": "npm ci",
+          "content": "Install exact versions from package-lock.json.",
+          "label": "Clean install"
         }
       ]
     },
     {
       "title": "Dependencies",
-      "items": [
+      "entries": [
         {
-          "title": "Add package",
-          "example": "npm install lodash",
-          "description": "Install and save as dependency."
+          "anchor": "npm install <package>",
+          "content": "Install and save as dependency."
         },
         {
-          "title": "Add dev dependency",
-          "example": "npm install -D typescript",
-          "description": "Install as devDependency."
+          "anchor": "npm install -D <package>",
+          "content": "Install as devDependency."
         },
         {
-          "title": "Add global",
-          "example": "npm install -g npm-check-updates",
-          "description": "Install package globally."
+          "anchor": "npm install -g <package>",
+          "content": "Install package globally."
         },
         {
-          "title": "Remove package",
-          "example": "npm uninstall lodash",
-          "description": "Remove package and update package.json."
+          "anchor": "npm uninstall <package>",
+          "content": "Remove package and update package.json."
         },
         {
-          "title": "List installed",
-          "example": "npm ls --depth=0",
-          "description": "Show top-level installed packages."
+          "anchor": "npm ls --depth=0",
+          "content": "Show top-level installed packages."
         }
       ]
     },
     {
       "title": "Scripts",
-      "items": [
+      "entries": [
         {
-          "title": "Run script",
-          "example": "npm run build",
-          "description": "Execute a script defined in package.json."
+          "anchor": "npm run <script>",
+          "content": "Execute a script defined in package.json."
         },
         {
-          "title": "Run test",
-          "example": "npm test",
-          "description": "Run the test script (shorthand)."
+          "anchor": "npm test",
+          "content": "Run the test script (shorthand)."
         },
         {
-          "title": "Run start",
-          "example": "npm start",
-          "description": "Run the start script (shorthand)."
+          "anchor": "npm start",
+          "content": "Run the start script (shorthand)."
         },
         {
-          "title": "List scripts",
-          "example": "npm run",
-          "description": "Show all available scripts."
+          "anchor": "npm run",
+          "content": "Show all available scripts."
         }
       ]
     },
     {
       "title": "Updates",
-      "items": [
+      "entries": [
         {
-          "title": "Check outdated",
-          "example": "npm outdated",
-          "description": "Show packages with newer versions available."
+          "anchor": "npm outdated",
+          "content": "Show packages with newer versions available."
         },
         {
-          "title": "Update packages",
-          "example": "npm update",
-          "description": "Update packages within semver range."
+          "anchor": "npm update",
+          "content": "Update packages within semver range."
         },
         {
-          "title": "Update npm",
-          "example": "npm install -g npm@latest",
-          "description": "Update npm itself to latest version."
+          "anchor": "npm install -g npm@latest",
+          "content": "Update npm itself to latest version."
         }
       ]
     },
     {
       "title": "Info & Debug",
-      "items": [
+      "entries": [
         {
-          "title": "View package info",
-          "example": "npm info react",
-          "description": "Show registry information for a package."
+          "anchor": "npm info <package>",
+          "content": "Show registry information for a package."
         },
         {
-          "title": "Check for vulnerabilities",
-          "example": "npm audit",
-          "description": "Scan dependencies for security issues."
+          "anchor": "npm audit",
+          "content": "Scan dependencies for security issues."
         },
         {
-          "title": "Fix vulnerabilities",
-          "example": "npm audit fix",
-          "description": "Automatically fix security issues when possible."
+          "anchor": "npm audit fix",
+          "content": "Automatically fix security issues when possible."
         },
         {
-          "title": "Why installed",
-          "example": "npm explain lodash",
-          "description": "Show why a package is installed."
+          "anchor": "npm explain <package>",
+          "content": "Show why a package is installed."
         }
       ]
     },
     {
       "title": "Publishing",
-      "items": [
+      "entries": [
         {
-          "title": "Login",
-          "example": "npm login",
-          "description": "Authenticate with npm registry."
+          "anchor": "npm login",
+          "content": "Authenticate with npm registry."
         },
         {
-          "title": "Publish",
-          "example": "npm publish",
-          "description": "Publish package to registry."
+          "anchor": "npm publish",
+          "content": "Publish package to registry."
         },
         {
-          "title": "Bump version",
-          "example": "npm version patch",
-          "description": "Increment version (patch/minor/major)."
+          "anchor": "npm version <patch|minor|major>",
+          "content": "Increment version (patch/minor/major)."
         }
       ]
     }

--- a/packages/chson-registry/cheatsheets/vim/core.chson.json
+++ b/packages/chson-registry/cheatsheets/vim/core.chson.json
@@ -1,9 +1,12 @@
 {
-  "$schema": "https://chson.dev/schema/v1/chson.schema.json",
+  "$schema": "https://chson.dev/schema/v2/chson.schema.json",
   "title": "Vim Essentials",
   "version": "9.x",
   "publicationDate": "2026-01-16",
   "description": "Essential Vim commands for text editing.",
+  "retrievalDirection": "mechanism-to-meaning",
+  "anchorLabel": "Example",
+  "contentLabel": "Description",
   "metadata": {
     "homepage": "https://www.vim.org/",
     "category": "editor"
@@ -11,211 +14,194 @@
   "sections": [
     {
       "title": "Modes",
-      "items": [
+      "entries": [
         {
-          "title": "Normal mode",
-          "example": "Esc",
-          "description": "Return to normal mode from any other mode."
+          "anchor": "Esc",
+          "content": "Return to normal mode from any other mode.",
+          "label": "Normal mode"
         },
         {
-          "title": "Insert mode",
-          "example": "i",
-          "description": "Enter insert mode before cursor."
+          "anchor": "i",
+          "content": "Enter insert mode before cursor.",
+          "label": "Insert mode"
         },
         {
-          "title": "Append",
-          "example": "a",
-          "description": "Enter insert mode after cursor."
+          "anchor": "a",
+          "content": "Enter insert mode after cursor.",
+          "label": "Append"
         },
         {
-          "title": "Visual mode",
-          "example": "v",
-          "description": "Start character-wise visual selection."
+          "anchor": "v",
+          "content": "Start character-wise visual selection.",
+          "label": "Visual mode"
         },
         {
-          "title": "Visual line",
-          "example": "V",
-          "description": "Start line-wise visual selection."
+          "anchor": "V",
+          "content": "Start line-wise visual selection.",
+          "label": "Visual line"
         },
         {
-          "title": "Command mode",
-          "example": ":",
-          "description": "Enter command-line mode."
+          "anchor": ":",
+          "content": "Enter command-line mode.",
+          "label": "Command mode"
         }
       ]
     },
     {
       "title": "Navigation",
-      "items": [
+      "entries": [
         {
-          "title": "Move by character",
-          "example": "h j k l",
-          "description": "Left, down, up, right."
+          "anchor": "h j k l",
+          "content": "Left, down, up, right.",
+          "label": "Move by character"
         },
         {
-          "title": "Move by word",
-          "example": "w",
-          "description": "Jump to start of next word."
+          "anchor": "w",
+          "content": "Jump to start of next word."
         },
         {
-          "title": "Move by word back",
-          "example": "b",
-          "description": "Jump to start of previous word."
+          "anchor": "b",
+          "content": "Jump to start of previous word."
         },
         {
-          "title": "Line start",
-          "example": "0",
-          "description": "Jump to beginning of line."
+          "anchor": "0",
+          "content": "Jump to beginning of line.",
+          "label": "Line start"
         },
         {
-          "title": "Line end",
-          "example": "$",
-          "description": "Jump to end of line."
+          "anchor": "$",
+          "content": "Jump to end of line.",
+          "label": "Line end"
         },
         {
-          "title": "File start",
-          "example": "gg",
-          "description": "Jump to first line of file."
+          "anchor": "gg",
+          "content": "Jump to first line of file.",
+          "label": "File start"
         },
         {
-          "title": "File end",
-          "example": "G",
-          "description": "Jump to last line of file."
+          "anchor": "G",
+          "content": "Jump to last line of file.",
+          "label": "File end"
         },
         {
-          "title": "Go to line",
-          "example": "42G",
-          "description": "Jump to line 42."
+          "anchor": "<n>G",
+          "content": "Jump to line n.",
+          "label": "Go to line"
         }
       ]
     },
     {
       "title": "Editing",
-      "items": [
+      "entries": [
         {
-          "title": "Delete character",
-          "example": "x",
-          "description": "Delete character under cursor."
+          "anchor": "x",
+          "content": "Delete character under cursor."
         },
         {
-          "title": "Delete word",
-          "example": "dw",
-          "description": "Delete from cursor to start of next word."
+          "anchor": "dw",
+          "content": "Delete from cursor to start of next word."
         },
         {
-          "title": "Delete line",
-          "example": "dd",
-          "description": "Delete entire current line."
+          "anchor": "dd",
+          "content": "Delete entire current line."
         },
         {
-          "title": "Change word",
-          "example": "cw",
-          "description": "Delete word and enter insert mode."
+          "anchor": "cw",
+          "content": "Delete word and enter insert mode."
         },
         {
-          "title": "Change line",
-          "example": "cc",
-          "description": "Delete line and enter insert mode."
+          "anchor": "cc",
+          "content": "Delete line and enter insert mode."
         },
         {
-          "title": "Replace character",
-          "example": "r",
-          "description": "Replace single character under cursor."
+          "anchor": "r",
+          "content": "Replace single character under cursor."
         },
         {
-          "title": "Undo",
-          "example": "u",
-          "description": "Undo last change."
+          "anchor": "u",
+          "content": "Undo last change."
         },
         {
-          "title": "Redo",
-          "example": "Ctrl+r",
-          "description": "Redo last undone change."
+          "anchor": "Ctrl+r",
+          "content": "Redo last undone change."
         }
       ]
     },
     {
       "title": "Copy & Paste",
-      "items": [
+      "entries": [
         {
-          "title": "Yank line",
-          "example": "yy",
-          "description": "Copy current line."
+          "anchor": "yy",
+          "content": "Copy current line.",
+          "label": "Yank line"
         },
         {
-          "title": "Yank word",
-          "example": "yw",
-          "description": "Copy from cursor to start of next word."
+          "anchor": "yw",
+          "content": "Copy from cursor to start of next word.",
+          "label": "Yank word"
         },
         {
-          "title": "Paste after",
-          "example": "p",
-          "description": "Paste after cursor."
+          "anchor": "p",
+          "content": "Paste after cursor."
         },
         {
-          "title": "Paste before",
-          "example": "P",
-          "description": "Paste before cursor."
+          "anchor": "P",
+          "content": "Paste before cursor."
         }
       ]
     },
     {
       "title": "Search",
-      "items": [
+      "entries": [
         {
-          "title": "Search forward",
-          "example": "/pattern",
-          "description": "Search for pattern forward."
+          "anchor": "/<pattern>",
+          "content": "Search for pattern forward."
         },
         {
-          "title": "Search backward",
-          "example": "?pattern",
-          "description": "Search for pattern backward."
+          "anchor": "?<pattern>",
+          "content": "Search for pattern backward."
         },
         {
-          "title": "Next match",
-          "example": "n",
-          "description": "Jump to next search match."
+          "anchor": "n",
+          "content": "Jump to next search match."
         },
         {
-          "title": "Previous match",
-          "example": "N",
-          "description": "Jump to previous search match."
+          "anchor": "N",
+          "content": "Jump to previous search match."
         },
         {
-          "title": "Search and replace",
-          "example": ":%s/old/new/g",
-          "description": "Replace all occurrences in file."
+          "anchor": ":%s/<old>/<new>/g",
+          "content": "Replace all occurrences in file."
         }
       ]
     },
     {
       "title": "Files",
-      "items": [
+      "entries": [
         {
-          "title": "Save",
-          "example": ":w",
-          "description": "Write current file to disk."
+          "anchor": ":w",
+          "content": "Write current file to disk.",
+          "label": "Save"
         },
         {
-          "title": "Quit",
-          "example": ":q",
-          "description": "Quit (fails if unsaved changes)."
+          "anchor": ":q",
+          "content": "Quit (fails if unsaved changes).",
+          "label": "Quit"
         },
         {
-          "title": "Save and quit",
-          "example": ":wq",
-          "description": "Write and quit."
+          "anchor": ":wq",
+          "content": "Write and quit.",
+          "label": "Save and quit"
         },
         {
-          "title": "Force quit",
-          "example": ":q!",
-          "description": "Quit without saving changes."
+          "anchor": ":q!",
+          "content": "Quit without saving changes.",
+          "label": "Force quit"
         },
         {
-          "title": "Open file",
-          "example": ":e filename",
-          "description": "Open another file for editing."
+          "anchor": ":e <file>",
+          "content": "Open another file for editing.",
+          "label": "Open file"
         }
       ]
     }

--- a/packages/chson-schema/README.md
+++ b/packages/chson-schema/README.md
@@ -7,7 +7,7 @@ ChSON JSON Schema and auto-generated TypeScript type definitions.
 ### Import Schema (JSON)
 
 ```typescript
-import schemaV1 from "@chson/schema/v1" with { type: "json" };
+import schemaV2 from "@chson/schema/v2" with { type: "json" };
 ```
 
 ### Import TypeScript Types
@@ -26,6 +26,6 @@ npm run build
 
 ## Structure
 
-- `schema/v1/chson.schema.json` - JSON Schema (Draft 2020-12)
+- `schema/v2/chson.schema.json` - JSON Schema (Draft 2020-12) - current version
 - `types/index.d.ts` - Generated TypeScript types (auto-generated, gitignored)
 - `scripts/build-types.js` - Type generation script

--- a/packages/chson-schema/package.json
+++ b/packages/chson-schema/package.json
@@ -1,19 +1,23 @@
 {
   "name": "@chson/schema",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "private": true,
   "description": "ChSON JSON Schema and TypeScript type definitions",
   "type": "module",
-  "main": "./schema/v1/chson.schema.json",
-  "types": "./types/index.d.ts",
+  "main": "./schema/v2/chson.schema.json",
+  "types": "./types/v2.d.ts",
   "exports": {
     ".": {
-      "types": "./types/index.d.ts",
-      "default": "./schema/v1/chson.schema.json"
+      "types": "./types/v2.d.ts",
+      "default": "./schema/v2/chson.schema.json"
     },
     "./v1": "./schema/v1/chson.schema.json",
     "./v1/chson.schema.json": "./schema/v1/chson.schema.json",
-    "./types": "./types/index.d.ts"
+    "./v2": "./schema/v2/chson.schema.json",
+    "./v2/chson.schema.json": "./schema/v2/chson.schema.json",
+    "./types": "./types/v2.d.ts",
+    "./types/v1": "./types/v1.d.ts",
+    "./types/v2": "./types/v2.d.ts"
   },
   "files": [
     "schema",

--- a/packages/chson-schema/schema/v2/chson.schema.json
+++ b/packages/chson-schema/schema/v2/chson.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://chson.dev/schema/v2/chson.schema.json",
+  "title": "ChSON Cheatsheet",
+  "description": "A structured format for software cheatsheets, based on cognitive science principles of retrieval and chunking.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["title", "publicationDate", "description", "sections"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "JSON Schema reference URL."
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The name of this cheatsheet."
+    },
+    "version": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Version of the software this cheatsheet documents."
+    },
+    "publicationDate": {
+      "type": "string",
+      "anyOf": [
+        { "format": "date" },
+        { "format": "date-time" }
+      ],
+      "description": "When this cheatsheet was published or last updated."
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1,
+      "description": "A brief summary of what this cheatsheet covers."
+    },
+    "retrievalDirection": {
+      "type": "string",
+      "enum": ["intent-to-mechanism", "mechanism-to-meaning"],
+      "description": "The cognitive lookup direction for this cheatsheet. 'intent-to-mechanism': user knows what they want to do, needs the command/shortcut. 'mechanism-to-meaning': user sees a command/syntax, needs to understand what it does."
+    },
+    "anchorLabel": {
+      "type": "string",
+      "description": "Display name for the anchor column (default: 'Anchor'). Use 'Example' for code samples, 'Shortcut' for keyboard shortcuts, etc."
+    },
+    "contentLabel": {
+      "type": "string",
+      "description": "Display name for the content column (default: 'Content'). Use 'Description' for explanations, 'Action' for intent-based lookups, etc."
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Additional metadata (homepage, category, tags, etc.)."
+    },
+    "sections": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/section" },
+      "description": "Logical groupings of related entries (chunks)."
+    }
+  },
+  "$defs": {
+    "section": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["title", "entries"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The name of this section (chunk category)."
+        },
+        "description": {
+          "type": "string",
+          "description": "Optional explanation of what this section covers."
+        },
+        "entries": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/entry" },
+          "description": "The anchor-content pairs in this section."
+        }
+      }
+    },
+    "entry": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["anchor", "content"],
+      "properties": {
+        "anchor": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The retrieval anchor: what users scan for. Typically a command, shortcut, or action name."
+        },
+        "content": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The associated content: what users need to know once they find the anchor."
+        },
+        "label": {
+          "type": "string",
+          "description": "Optional human-readable label when the anchor is cryptic (e.g., 'gg' might have label 'Go to start')."
+        },
+        "comments": {
+          "description": "Optional notes, warnings, or additional context."
+        }
+      }
+    }
+  }
+}

--- a/research/README.md
+++ b/research/README.md
@@ -1,0 +1,31 @@
+# ChSON Research
+
+This directory contains theoretical and empirical research supporting ChSON design.
+
+## Documents
+
+### [Cognitive Foundations](./cognitive-foundations.md)
+
+A theoretical framework for understanding why cheatsheets work as cognitive tools.
+Synthesizes research from memory science, cognitive load theory, information
+foraging, and distributed cognition to propose:
+
+- **Retrieval Anchor / Associated Content** terminology for cheatsheet structure
+- A taxonomy of **retrieval directions** (intent→mechanism vs. mechanism→meaning)
+- Design principles grounded in established cognitive theories
+- Implications for the ChSON schema
+
+**Status**: Working draft
+
+## Future Research Directions
+
+- [ ] Empirical validation via eye-tracking studies
+- [ ] Survey of existing cheatsheet formats and their cognitive properties
+- [ ] Design heuristics with testable predictions
+- [ ] Integration with ChSON schema (explicit retrieval direction, anchor types)
+
+## Contributing
+
+This research is intended to evolve into publishable work. If you're interested
+in contributing empirical studies, literature reviews, or theoretical refinements,
+please open an issue or PR.

--- a/research/cognitive-foundations.md
+++ b/research/cognitive-foundations.md
@@ -1,0 +1,501 @@
+# Toward a Cognitive Theory of Cheatsheets
+
+**Status**: Working draft  
+**Started**: February 2026  
+**Authors**: [To be added]
+
+---
+
+## Abstract
+
+Cheatsheets are ubiquitous tools for software practitioners, yet no formal theory
+explains their cognitive function or provides principled design guidelines. This
+document synthesizes research from cognitive psychology, memory science, and
+human-computer interaction to propose a theoretical foundation for understanding
+why cheatsheets work and how they should be designed.
+
+We introduce the concepts of **retrieval anchor** and **associated content** as
+the fundamental structural elements, propose a taxonomy of **retrieval directions**,
+and identify design principles grounded in established cognitive theories.
+
+---
+
+## 1. Introduction
+
+### 1.1 The Problem
+
+Software cheatsheets exist in countless forms: quick reference cards, keyboard
+shortcut lists, command-line guides, API summaries. Despite their ubiquity, no
+systematic theory addresses:
+
+1. Why cheatsheets are cognitively effective
+2. What structural properties make some cheatsheets better than others
+3. How different types of content (commands vs. shortcuts vs. concepts) should
+   be organized differently
+
+### 1.2 A Motivating Observation
+
+Consider two common cheatsheet layouts:
+
+**Programming cheatsheet (e.g., Git)**:
+| Command | Description |
+|---------|-------------|
+| `git commit -m "msg"` | Create a commit with message |
+| `git stash` | Temporarily store changes |
+
+**Keyboard shortcut cheatsheet (e.g., VS Code)**:
+| Action | Shortcut |
+|--------|----------|
+| Save file | Cmd+S |
+| Find in files | Cmd+Shift+F |
+
+The columns appear to be "reversed." Why? Is there a principled explanation, or
+is this merely convention?
+
+### 1.3 Thesis
+
+We argue that both layouts follow the same underlying principle:
+
+> **The left column contains what the user knows (the retrieval anchor); the
+> right column contains what they need (the associated content).**
+
+This principle, combined with insights from memory research, information foraging
+theory, and cognitive load theory, forms the basis of a unified theory of
+cheatsheet design.
+
+---
+
+## 2. Theoretical Foundations
+
+### 2.1 Cheatsheets as External Cognitive Artifacts
+
+Clark and Chalmers' **Extended Mind Thesis** (1998) argues that cognitive
+processes can extend beyond the brain into the environment. External artifacts—
+notebooks, calculators, reference materials—function as part of our cognitive
+system when:
+
+1. They are reliably available
+2. Information in them is automatically endorsed
+3. They are easily accessible when needed
+
+Cheatsheets satisfy all three criteria for practitioners who keep them at hand.
+They function as **cognitive offloading devices**, reducing demands on working
+memory by externalizing retrieval.
+
+Hutchins' **Distributed Cognition** framework (1995) extends this view, analyzing
+how cognitive work is distributed across people, artifacts, and environments.
+A cheatsheet distributes the storage and retrieval of procedural knowledge to
+an external medium, freeing working memory for the actual task.
+
+**Key insight**: A cheatsheet is not merely a learning aid; it is a functional
+extension of the practitioner's memory system.
+
+### 2.2 The Cue-Target Structure
+
+The fundamental unit of a cheatsheet is a **paired associate**: two pieces of
+information linked together, where one serves as a retrieval cue for the other.
+
+From memory research terminology:
+
+| Term | Definition | Cheatsheet Role |
+|------|------------|-----------------|
+| **Cue** (stimulus, probe) | Information that triggers retrieval | Left column |
+| **Target** (response, trace) | Information to be retrieved | Right column |
+
+The paired-associate learning literature distinguishes:
+
+- **Forward recall**: Given A, retrieve B
+- **Backward recall**: Given B, retrieve A
+
+This distinction is critical for cheatsheet design, as different content types
+optimize for different retrieval directions.
+
+### 2.3 Chunking and Templates
+
+Miller (1956) established that working memory holds approximately 7±2 "chunks"
+of information (later refined to 4±1 by Cowan). Chase and Simon (1973) showed
+that expert chess players' superior memory arose from recognizing board positions
+as familiar **chunks** rather than individual pieces.
+
+Gobet's **CHREST model** (Chunk Hierarchy and REtrieval STructures) extends this
+with the concept of **templates**—chunks with variable **slots** that can be
+filled with specific values.
+
+**Cheatsheet implications**:
+
+1. The left column often represents a **chunk** or **template pattern**
+2. Well-designed entries match the user's existing chunk vocabulary
+3. For novices, cheatsheets *teach* new chunks; for experts, they *remind* of
+   rarely-used ones
+4. Slot notation (e.g., `git commit -m "<message>"`) maps directly to template
+   theory
+
+### 2.4 Information Foraging
+
+Pirolli and Card's **Information Foraging Theory** (1999) models how humans seek
+information using concepts from optimal foraging theory:
+
+- **Information scent**: Cues that indicate the likelihood of finding useful
+  information along a path
+- **Information patch**: A resource (page, document, section) as an information
+  source
+- **Informavores**: Humans as agents optimizing information-seeking behavior
+
+Cheatsheet users are foragers scanning for the right entry. The left column
+provides **information scent**; strong scent leads to faster, more accurate
+retrieval.
+
+**Design principle**: The retrieval anchor must provide strong, unambiguous scent.
+This explains why:
+- Code in monospace is more distinctive than prose
+- Visual formatting (bold, color, boxes) aids scanning
+- Consistent structure across entries enables pattern matching
+
+### 2.5 Cognitive Load Theory
+
+Sweller's **Cognitive Load Theory** (1988) distinguishes three types of load:
+
+| Load Type | Definition | Cheatsheet Effect |
+|-----------|------------|-------------------|
+| **Intrinsic** | Complexity inherent to the material | Unchanged |
+| **Extraneous** | Load caused by poor presentation | **Reduced** by good design |
+| **Germane** | Load devoted to schema construction | **Enabled** by freeing WM |
+
+Cheatsheets reduce extraneous load by:
+- Pre-organizing information (no search required)
+- Consistent formatting (reduces parsing effort)
+- Proximity of related information (reduces split attention)
+
+This frees working memory for the actual task—germane processing of the problem
+at hand.
+
+### 2.6 Dual Coding Theory
+
+Paivio's **Dual Coding Theory** (1971) proposes that humans process verbal
+(symbolic) and visual (imagery) information through separate channels:
+
+- **Logogens**: Units for verbal information
+- **Imagens**: Units for visual/spatial information
+- **Referential connections**: Links between the two systems
+
+The **picture superiority effect** shows that distinctive visual elements are
+remembered better than text alone.
+
+**Cheatsheet implications**:
+- Code, commands, and key combinations should be visually distinctive (monospace,
+  highlighting, icons)
+- This visual coding creates a second retrieval pathway
+- The asymmetry between left (visual) and right (verbal) columns may aid scanning
+
+---
+
+## 3. Proposed Terminology
+
+We propose the following terminology for discussing cheatsheet structure:
+
+### 3.1 Primary Terms
+
+| Concept | Proposed Term | Definition |
+|---------|---------------|------------|
+| Left column content | **Retrieval Anchor** | The element users scan for; triggers recognition and retrieval |
+| Right column content | **Associated Content** | The information retrieved once the anchor is recognized |
+
+**Rationale for "Retrieval Anchor"**:
+- "Retrieval" connects to memory research terminology
+- "Anchor" captures the scanning/foraging behavior—it's what attention anchors on
+- Avoids "cue" (too narrow, implies learning context) and "key" (overloaded in
+  programming contexts)
+
+**Rationale for "Associated Content"**:
+- Neutral term that accommodates meanings, procedures, mechanisms, or any
+  target information
+- "Associated" reflects the paired-associate memory structure
+- Avoids "value" (overloaded) and "description" (too narrow)
+
+### 3.2 Secondary Terms
+
+| Term | Definition |
+|------|------------|
+| **Retrieval direction** | The implicit query direction: what the user knows → what they need |
+| **Scent strength** | How visually and semantically distinctive the retrieval anchor is |
+| **Chunk density** | The number of recognizable patterns per section or sheet |
+| **Slot pattern** | A retrieval anchor containing variable placeholders (e.g., `<filename>`) |
+| **Entry** | A single anchor-content pair; the atomic unit of a cheatsheet |
+| **Section** | A group of related entries under a common heading |
+
+### 3.3 Alternative Terms Considered
+
+| Pair | Source | Reason Not Selected |
+|------|--------|---------------------|
+| Cue → Target | Memory research | Too clinical; implies learning rather than reference use |
+| Pattern → Procedure | Expertise literature | Too narrow; doesn't fit conceptual or shortcut content |
+| Trigger → Response | Behaviorism | Unwanted theoretical baggage |
+| Index → Entry | Library science | Obscures cognitive function |
+| Key → Value | Programming | Overloaded; cheatsheets often describe key-value systems |
+
+---
+
+## 4. A Taxonomy of Retrieval Directions
+
+Different cheatsheet types optimize for different retrieval directions based on
+what users typically know vs. need.
+
+### 4.1 The Two Primary Directions
+
+**Intent → Mechanism** (Action-first):
+- User knows: What they want to accomplish
+- User needs: How to accomplish it
+- Example: "How do I save?" → `Cmd+S`
+
+**Mechanism → Meaning** (Syntax-first):
+- User knows: A command or syntax they've seen
+- User needs: What it does
+- Example: `git stash` → "Temporarily store changes"
+
+### 4.2 Mapping Content Types to Retrieval Directions
+
+| Content Type | Primary Direction | Retrieval Anchor | Associated Content |
+|--------------|-------------------|------------------|-------------------|
+| Keyboard shortcuts | Intent → Mechanism | Action description | Key combination |
+| CLI commands (learning) | Intent → Mechanism | Task description | Command syntax |
+| CLI commands (reference) | Mechanism → Meaning | Command syntax | Explanation |
+| API reference | Mechanism → Meaning | Method signature | Description + params |
+| Config options | Mechanism → Meaning | Option name | Accepted values + effect |
+| Concepts/glossary | Term → Definition | Term | Definition |
+
+### 4.3 Bidirectional Cheatsheets
+
+Some cheatsheets serve both directions. This is cognitively demanding because:
+- Users must determine which column to scan
+- The layout cannot be optimized for both directions simultaneously
+
+**Design strategies**:
+1. Choose a primary direction and optimize for it
+2. Provide two views (command-first vs. task-first)
+3. Use strong visual differentiation between anchor and content
+
+---
+
+## 5. Design Principles
+
+Based on the theoretical foundations, we derive the following design principles:
+
+### 5.1 Structural Principles
+
+**P1: Consistent retrieval direction**  
+All entries within a section should share the same retrieval direction. Mixing
+"intent → mechanism" and "mechanism → meaning" entries creates scanning confusion.
+
+**P2: Strong scent in anchors**  
+Retrieval anchors should be visually distinctive and semantically precise.
+Monospace formatting, syntax highlighting, and icons increase scent strength.
+
+**P3: Atomic entries**  
+Each entry should capture one chunk. If an entry requires multiple sub-steps,
+it may need decomposition or hierarchical structure.
+
+**P4: Slot notation for templates**  
+Variable components should use consistent placeholder notation (e.g., `<file>`,
+`{name}`, `$VAR`) to signal template slots.
+
+### 5.2 Cognitive Load Principles
+
+**P5: Minimize split attention**  
+Keep anchor and content visually proximate. Two-column tables excel here;
+separated lists require eye movement between sections.
+
+**P6: Consistent formatting**  
+Visual consistency reduces parsing effort. Every entry should follow the same
+structural pattern within a section.
+
+**P7: Progressive disclosure**  
+Core/common entries first; edge cases and advanced options later. This respects
+the user's likely scanning pattern.
+
+### 5.3 Chunking Principles
+
+**P8: Match user vocabulary**  
+Anchors should use terms the target audience already knows. A Git cheatsheet
+for beginners might anchor on "undo last commit"; one for experts might anchor
+on `git reset`.
+
+**P9: Group by semantic category**  
+Sections should reflect conceptual chunks (e.g., "Branching," "Staging," "Remote
+Operations"), not alphabetical order.
+
+**P10: Reasonable section size**  
+Sections should be scannable at a glance. While Miller's 7±2 guideline provides
+a useful heuristic, practical considerations often require more entries per
+section. The key constraint is that users should be able to visually parse the
+section without losing context. Sections of 10-15 entries are acceptable when
+entries are visually consistent and the section has a clear semantic boundary.
+
+---
+
+## 6. Implications for ChSON
+
+This theoretical framework has direct implications for the ChSON format:
+
+### 6.1 Schema Alignment
+
+The ChSON v2 schema structure maps to our terminology:
+
+| ChSON v2 Element | Cognitive Role |
+|------------------|----------------|
+| `entry.anchor` | Retrieval anchor |
+| `entry.content` | Associated content |
+| `entry.label` | Human-readable label for cryptic anchors |
+| `section.title` | Chunk category label |
+| `section.entries` | Entries within a chunk |
+| `retrievalDirection` | Explicit declaration of lookup direction |
+| `anchorLabel` | Domain-appropriate name for anchor column |
+| `contentLabel` | Domain-appropriate name for content column |
+
+### 6.2 Implemented in v2
+
+The following features have been implemented in ChSON v2:
+
+1. **`retrievalDirection`**: Explicit declaration at sheet level
+   - Values: `"intent-to-mechanism"`, `"mechanism-to-meaning"`
+   
+2. **Renamed terminology**: 
+   - `items` → `entries`
+   - `item.title` + `item.example` → `entry.anchor`
+   - `item.description` → `entry.content`
+   - New `entry.label` for human-readable names when anchor is cryptic
+
+3. **Custom column labels**:
+   - `anchorLabel`: Display name for anchor column (e.g., "Example", "Shortcut", "Command")
+   - `contentLabel`: Display name for content column (e.g., "Description", "Action", "Effect")
+
+### 6.3 Potential Future Extensions
+
+Based on this theory, future ChSON versions might consider:
+
+1. **`anchorType`**: Semantic type of the retrieval anchor
+   - Values: `command`, `shortcut`, `term`, `action`, `config-key`
+   
+2. **`slots`**: Explicit declaration of template variables
+   - Enables validation and interactive rendering
+
+3. **`scentStrength`** metadata: Scoring or flagging of anchor distinctiveness
+
+### 6.3 Rendering Considerations
+
+Renderers should:
+- Apply visual differentiation to anchors (monospace, highlighting)
+- Preserve two-column proximity where possible
+- Consider retrieval direction when ordering columns
+
+---
+
+## 7. Open Questions and Future Research
+
+### 7.1 Empirical Validation
+
+The theoretical framework generates testable predictions:
+
+1. **Eye-tracking studies**: Do users fixate on retrieval anchors before scanning
+   associated content?
+2. **Retrieval time**: Do cheatsheets with stronger scent yield faster lookups?
+3. **Error rates**: Do reversed columns increase lookup errors?
+4. **Learning transfer**: Do cheatsheets accelerate chunking in novices?
+
+### 7.2 Theoretical Gaps
+
+Areas requiring further investigation:
+
+1. **Optimal information density**: What is the theoretical limit on entries per
+   section or page before cognitive overload?
+   
+2. **Visual chunking in text**: How do monospace fonts, boxes, and syntax
+   highlighting create visual chunks? Typography research may inform this.
+   
+3. **Mobile/constrained displays**: How should two-column structure adapt when
+   space is limited?
+   
+4. **Searchable vs. scannable**: Digital cheatsheets allow search; does this
+   change optimal design?
+
+5. **Multi-modal cheatsheets**: How do audio, video, or interactive elements
+   integrate with the anchor-content model?
+
+### 7.3 Adjacent Fields to Explore
+
+- **Instructional design**: Merrill's First Principles, van Merriënboer's 4C/ID
+- **Technical writing**: Information mapping (Robert Horn)
+- **Library science**: Subject indexing, controlled vocabularies
+- **UX research**: Scanning patterns, visual hierarchy
+
+---
+
+## 8. Conclusion
+
+Cheatsheets are more than convenient summaries; they are cognitive tools that
+extend human memory by externalizing retrieval structures. Their effectiveness
+depends on alignment with fundamental principles of memory, attention, and
+information seeking.
+
+The core insight—that cheatsheets are **cue-target structures optimized for
+scanning**—unifies observations about column ordering, visual formatting, and
+content organization. The proposed terminology (retrieval anchor, associated
+content, retrieval direction) provides a vocabulary for discussing and improving
+cheatsheet design.
+
+This framework is a starting point. Empirical validation, refinement of design
+principles, and integration with the ChSON format remain as future work.
+
+---
+
+## References
+
+Chase, W. G., & Simon, H. A. (1973). Perception in chess. *Cognitive Psychology*,
+4(1), 55-81.
+
+Clark, A., & Chalmers, D. (1998). The extended mind. *Analysis*, 58(1), 7-19.
+
+Cowan, N. (2001). The magical number 4 in short-term memory: A reconsideration
+of mental storage capacity. *Behavioral and Brain Sciences*, 24(1), 87-114.
+
+Gobet, F., & Simon, H. A. (1996). Templates in chess memory: A mechanism for
+recalling several boards. *Cognitive Psychology*, 31(1), 1-40.
+
+Hutchins, E. (1995). *Cognition in the Wild*. MIT Press.
+
+Miller, G. A. (1956). The magical number seven, plus or minus two: Some limits
+on our capacity for processing information. *Psychological Review*, 63(2), 81-97.
+
+Paivio, A. (1971). *Imagery and Verbal Processes*. Holt, Rinehart, and Winston.
+
+Pirolli, P., & Card, S. (1999). Information foraging. *Psychological Review*,
+106(4), 643-675.
+
+Sweller, J. (1988). Cognitive load during problem solving: Effects on learning.
+*Cognitive Science*, 12(2), 257-285.
+
+---
+
+## Appendix A: Glossary of Proposed Terms
+
+| Term | Definition |
+|------|------------|
+| **Associated Content** | The information retrieved once a retrieval anchor is recognized; typically the right column of a cheatsheet |
+| **Chunk** | A familiar pattern recognized as a cognitive unit |
+| **Chunk Density** | The number of recognizable patterns per section or sheet |
+| **Entry** | A single anchor-content pair; the atomic unit of a cheatsheet |
+| **Information Scent** | Visual or semantic cues indicating the likelihood of finding desired information |
+| **Retrieval Anchor** | The element users scan for in a cheatsheet; triggers recognition and retrieval |
+| **Retrieval Direction** | The implicit query direction: what the user knows → what they need |
+| **Scent Strength** | The degree to which a retrieval anchor is visually and semantically distinctive |
+| **Section** | A group of related entries under a common heading |
+| **Slot** | A variable position within a template pattern |
+| **Slot Pattern** | A retrieval anchor containing variable placeholders |
+| **Template** | A chunk with slots that can be filled with specific values |
+
+---
+
+## Appendix B: Document History
+
+| Date | Change |
+|------|--------|
+| 2026-02 | Initial draft created |


### PR DESCRIPTION
- Migrate all cheatsheets to v2 schema (anchor/content terminology)
- Add retrieval direction-aware styling: mechanism columns render as
  code, intent columns render as plain text (per cognitive foundations)
- Add Atuin keybindings cheatsheet as intent-to-mechanism example
- Add /docs page with core concepts, schema reference, and best practices
- Update homepage with v2 schema example and link to docs
- Update CLI renderer to apply <pre> tags based on retrieval direction
- Update site cheatsheet pages with CodeCell/TextCell based on direction
- Relax P10 guideline to 10-15 entries per section
- Update all READMEs to v2 terminology
