### PR TITLE
fix(css): correct Shiki CSS variable name for light theme

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -253,10 +253,10 @@
   background-color: var(--muted);
 }
 
-/* Light mode: use the light theme colors */
+/* Light mode: use the default theme colors */
 .shiki,
 .shiki span {
-  color: var(--shiki-light) !important;
+  color: var(--shiki) !important;
   background-color: transparent !important;
 }
 


### PR DESCRIPTION
## Summary

Fixes incorrect CSS variable name for Shiki syntax highlighting light theme.

### Problem
The CSS was using `--shiki-light` which doesn't exist in Shiki 3.x. With dual themes, Shiki generates:
- `--shiki` for the default (light) theme colors
- `--shiki-dark` for the dark theme colors

### Solution
Changed `--shiki-light` to `--shiki` so the light mode colors are properly applied.

### Changes
- Updated `apps/web/app/globals.css` to use correct CSS variable name