### PR TITLE
feat(registry): add pack generation and metadata mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,13 @@ You can distribute `.chson.json` collections using shadcn's registry format (`re
 Generate a shadcn-compatible registry source tree from ChSON files:
 
 ```bash
-node packages/chson-cli/src/chson.js registry init packages/chson-registry/cheatsheets --out examples/chson-shadcn-registry --namespace @chson --homepage https://chson.dev
+node packages/chson-cli/src/chson.js registry init packages/chson-registry/cheatsheets --out examples/chson-shadcn-registry --namespace @chson --homepage https://chson.dev --packs by-directory
 ```
+
+Useful flags:
+
+- `--packs by-directory` creates pack items such as `git-pack` using `registryDependencies`
+- `--fail-on-collision` fails when item slug collisions are detected
 
 Then build installable registry payloads:
 
@@ -113,6 +118,7 @@ and install with:
 
 ```bash
 npx shadcn@latest add @chson/git-core
+npx shadcn@latest add @chson/git-pack
 ```
 
 See docs: `/docs/registries` and prototype: `https://github.com/carlesandres/chson-files/tree/main/json-registry`.

--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -67,7 +67,7 @@ The CLI validates against the ChSON schema at `https://chson.dev/schema/chson.sc
 You can generate a shadcn-compatible registry source tree from `.chson.json` files:
 
 ```bash
-node packages/chson-cli/src/chson.js registry init packages/chson-registry/cheatsheets --out examples/chson-shadcn-registry --namespace @chson --homepage https://chson.dev
+node packages/chson-cli/src/chson.js registry init packages/chson-registry/cheatsheets --out examples/chson-shadcn-registry --namespace @chson --homepage https://chson.dev --packs by-directory
 ```
 
 This generates `registry.json` and `registry/default/**` files that can be built with `shadcn build`.
@@ -76,5 +76,11 @@ Defaults:
 
 - target base directory: `chson-files` (`~/chson-files/...` when installed)
 - namespace: `@chson`
+- packs mode: `none` (optional `by-directory` generates `registryDependencies` pack items)
+
+Optional flags:
+
+- `--packs by-directory` creates installable pack items per directory (for example `git-pack`)
+- `--fail-on-collision` exits when two paths map to the same item slug instead of auto-suffixing (`-2`, `-3`)
 
 See [Registries](/docs/registries) for the full publisher and consumer workflow.

--- a/apps/web/content/docs/registries.mdx
+++ b/apps/web/content/docs/registries.mdx
@@ -33,7 +33,7 @@ There is also an in-repo example under `examples/chson-shadcn-registry/` used by
 Use the ChSON CLI to scaffold a shadcn-compatible registry source tree:
 
 ```bash
-node packages/chson-cli/src/chson.js registry init packages/chson-registry/cheatsheets --out examples/chson-shadcn-registry --namespace @chson --homepage https://chson.dev
+node packages/chson-cli/src/chson.js registry init packages/chson-registry/cheatsheets --out examples/chson-shadcn-registry --namespace @chson --homepage https://chson.dev --packs by-directory
 ```
 
 Defaults:
@@ -41,6 +41,7 @@ Defaults:
 - Namespace: `@chson`
 - Installed target base directory: `~/chson-files/...`
 - Output directory: `registry/`
+- Packs mode: `none` (optional `by-directory`)
 
 The command generates:
 
@@ -52,6 +53,17 @@ Each item is emitted as `registry:item` with a `registry:file` entry targeting:
 ```text
 ~/chson-files/<product>/<name>.chson.json
 ```
+
+Metadata mapping:
+
+- `tags` -> `keywords`
+- `documentType` + first path segment -> `categories`
+- `publicationDate`, `retrievalDirection`, `version`, `homepage`, `documentType` -> `meta`
+
+Optional packs:
+
+- `--packs by-directory` adds aggregate items (for example `git-pack`)
+- Pack items install their children via `registryDependencies`
 
 ## Build and publish
 
@@ -84,6 +96,12 @@ Install one cheatsheet item:
 npx shadcn@latest add @chson/git-core
 ```
 
+Install a pack item:
+
+```bash
+npx shadcn@latest add @chson/git-pack
+```
+
 Validate installed files:
 
 ```bash
@@ -93,5 +111,6 @@ chson validate chson-files
 ## Notes
 
 - Item names come from file paths (for example `git/core.chson.json` -> `git-core`)
+- Use `--fail-on-collision` to enforce strict item naming and fail instead of suffixing on slug collisions
 - For private registries, use shadcn's `registries` object form with auth headers and env vars
 - Prefer HTTPS for hosted registries

--- a/examples/chson-shadcn-registry/README.md
+++ b/examples/chson-shadcn-registry/README.md
@@ -24,6 +24,9 @@ Then install an item in another project:
 
 ```bash
 npx shadcn@latest add http://localhost:3000/r/git-core.json
+npx shadcn@latest add http://localhost:3000/r/git-pack.json
 ```
 
 The file is installed into `~/chson-files/...` based on each item's `target` path.
+
+`git-pack` is an aggregate item that installs multiple cheatsheets through `registryDependencies`.

--- a/examples/chson-shadcn-registry/registry.json
+++ b/examples/chson-shadcn-registry/registry.json
@@ -8,6 +8,20 @@
       "type": "registry:item",
       "title": "Atuin Keybindings",
       "description": "Keyboard shortcuts for Atuin's interactive shell history search UI.",
+      "categories": [
+        "atuin"
+      ],
+      "keywords": [
+        "cli",
+        "shell",
+        "keybindings"
+      ],
+      "meta": {
+        "publicationDate": "2026-02-15",
+        "retrievalDirection": "intent-to-mechanism",
+        "version": "18.x",
+        "homepage": "https://atuin.sh/"
+      },
       "files": [
         {
           "path": "registry/default/atuin/keybindings.chson.json",
@@ -21,6 +35,21 @@
       "type": "registry:item",
       "title": "Release Checklist",
       "description": "Pre-release, release, and post-release checks for safe production deployments.",
+      "categories": [
+        "checklist",
+        "devops"
+      ],
+      "keywords": [
+        "devops",
+        "release",
+        "checklist"
+      ],
+      "meta": {
+        "publicationDate": "2026-02-23",
+        "retrievalDirection": "intent-to-mechanism",
+        "version": "1.0",
+        "documentType": "checklist"
+      },
       "files": [
         {
           "path": "registry/default/devops/release-checklist.chson.json",
@@ -34,6 +63,20 @@
       "type": "registry:item",
       "title": "Docker Essentials",
       "description": "Essential Docker commands for container management.",
+      "categories": [
+        "docker"
+      ],
+      "keywords": [
+        "cli",
+        "containers",
+        "devops"
+      ],
+      "meta": {
+        "publicationDate": "2026-01-16",
+        "retrievalDirection": "mechanism-to-meaning",
+        "version": "24.x",
+        "homepage": "https://docs.docker.com/"
+      },
       "files": [
         {
           "path": "registry/default/docker/core.chson.json",
@@ -47,6 +90,19 @@
       "type": "registry:item",
       "title": "Git Essentials",
       "description": "Essential git commands for day-to-day development.",
+      "categories": [
+        "git"
+      ],
+      "keywords": [
+        "cli",
+        "version-control"
+      ],
+      "meta": {
+        "publicationDate": "2026-01-16",
+        "retrievalDirection": "mechanism-to-meaning",
+        "version": "2.x",
+        "homepage": "https://git-scm.com/"
+      },
       "files": [
         {
           "path": "registry/default/git/core.chson.json",
@@ -60,6 +116,21 @@
       "type": "registry:item",
       "title": "Git Rebase TLDR",
       "description": "Quick reference for when and how to use git rebase safely.",
+      "categories": [
+        "tldr",
+        "git"
+      ],
+      "keywords": [
+        "git",
+        "tldr",
+        "version-control"
+      ],
+      "meta": {
+        "publicationDate": "2026-02-23",
+        "retrievalDirection": "intent-to-mechanism",
+        "version": "2.x",
+        "documentType": "tldr"
+      },
       "files": [
         {
           "path": "registry/default/git/rebase-tldr.chson.json",
@@ -73,6 +144,21 @@
       "type": "registry:item",
       "title": "Kubernetes Pod Troubleshooting Runbook",
       "description": "Operational runbook for diagnosing and recovering unhealthy Kubernetes pods.",
+      "categories": [
+        "runbook",
+        "kubernetes"
+      ],
+      "keywords": [
+        "kubernetes",
+        "ops",
+        "runbook"
+      ],
+      "meta": {
+        "publicationDate": "2026-02-23",
+        "retrievalDirection": "intent-to-mechanism",
+        "version": "1.29+",
+        "documentType": "runbook"
+      },
       "files": [
         {
           "path": "registry/default/kubernetes/pod-troubleshooting-runbook.chson.json",
@@ -86,6 +172,20 @@
       "type": "registry:item",
       "title": "npm Essentials",
       "description": "Essential npm commands for Node.js package management.",
+      "categories": [
+        "npm"
+      ],
+      "keywords": [
+        "cli",
+        "nodejs",
+        "package-manager"
+      ],
+      "meta": {
+        "publicationDate": "2026-01-16",
+        "retrievalDirection": "mechanism-to-meaning",
+        "version": "10.x",
+        "homepage": "https://docs.npmjs.com/"
+      },
       "files": [
         {
           "path": "registry/default/npm/core.chson.json",
@@ -99,6 +199,19 @@
       "type": "registry:item",
       "title": "Vim Essentials",
       "description": "Essential Vim commands for text editing.",
+      "categories": [
+        "vim"
+      ],
+      "keywords": [
+        "editor",
+        "cli"
+      ],
+      "meta": {
+        "publicationDate": "2026-01-16",
+        "retrievalDirection": "mechanism-to-meaning",
+        "version": "9.x",
+        "homepage": "https://www.vim.org/"
+      },
       "files": [
         {
           "path": "registry/default/vim/core.chson.json",
@@ -112,12 +225,45 @@
       "type": "registry:item",
       "title": "Web Performance Bookmarks",
       "description": "Curated references for measuring and improving frontend performance.",
+      "categories": [
+        "bookmarks",
+        "web"
+      ],
+      "keywords": [
+        "web",
+        "performance",
+        "bookmarks"
+      ],
+      "meta": {
+        "publicationDate": "2026-02-23",
+        "retrievalDirection": "intent-to-mechanism",
+        "version": "2026",
+        "documentType": "bookmarks"
+      },
       "files": [
         {
           "path": "registry/default/web/performance-bookmarks.chson.json",
           "type": "registry:file",
           "target": "~/chson-files/web/performance-bookmarks.chson.json"
         }
+      ]
+    },
+    {
+      "name": "git-pack",
+      "type": "registry:item",
+      "title": "Git Pack",
+      "description": "Installs 2 ChSON files from git.",
+      "categories": [
+        "pack"
+      ],
+      "meta": {
+        "packStrategy": "by-directory",
+        "group": "git",
+        "itemCount": 2
+      },
+      "registryDependencies": [
+        "git-core",
+        "git-rebase-tldr"
       ]
     }
   ]

--- a/examples/chson-shadcn-registry/scripts/check-built-registry.mjs
+++ b/examples/chson-shadcn-registry/scripts/check-built-registry.mjs
@@ -14,6 +14,12 @@ if (!Array.isArray(registryIndex.items) || registryIndex.items.length === 0) {
   throw new Error("Built registry.json has no items");
 }
 
+const itemNames = new Set(
+  registryIndex.items
+    .map((item) => item?.name)
+    .filter((name) => typeof name === "string" && name.length > 0),
+);
+
 for (const item of registryIndex.items) {
   if (!item.name) {
     throw new Error("Encountered item without a name in built registry index");
@@ -24,7 +30,17 @@ for (const item of registryIndex.items) {
     throw new Error(`Missing item payload: ${itemFilePath}`);
   }
 
-  JSON.parse(fs.readFileSync(itemFilePath, "utf8"));
+  const payload = JSON.parse(fs.readFileSync(itemFilePath, "utf8"));
+
+  if (Array.isArray(payload.registryDependencies)) {
+    for (const dependency of payload.registryDependencies) {
+      if (!itemNames.has(dependency)) {
+        throw new Error(
+          `Item '${item.name}' references unknown registry dependency '${dependency}'`,
+        );
+      }
+    }
+  }
 }
 
 console.log(

--- a/packages/chson-cli/src/chson.js
+++ b/packages/chson-cli/src/chson.js
@@ -17,12 +17,13 @@ function usage() {
     "Usage:",
     "  chson validate <file-or-dir> [...more]",
     "  chson render markdown <file-or-dir> [...more] [--out <dir>]",
-    "  chson registry init <file-or-dir> [...more] [--out <dir>] [--target-base <dir>] [--namespace <name>] [--homepage <url>]",
+    "  chson registry init <file-or-dir> [...more] [--out <dir>] [--target-base <dir>] [--namespace <name>] [--homepage <url>] [--packs <mode>] [--fail-on-collision]",
     "",
     "Notes:",
     "  - If a directory is provided, scans for *.chson.json recursively.",
     "  - render outputs 2-column Markdown tables.",
     "  - registry init generates a shadcn-compatible registry source tree.",
+    "  - --packs supports: none (default), by-directory",
   ].join("\n");
 }
 
@@ -91,6 +92,22 @@ function uniqueSlug(baseSlug, seen) {
   return next;
 }
 
+function titleCase(input) {
+  return String(input)
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((chunk) => `${chunk[0].toUpperCase()}${chunk.slice(1).toLowerCase()}`)
+    .join(" ");
+}
+
+function requireFlagValue(args, index, flagName) {
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`Missing value for ${flagName}`);
+  }
+  return value;
+}
+
 function collectRegistrySources(inputs) {
   const sources = [];
   for (const input of inputs) {
@@ -107,6 +124,9 @@ function collectRegistrySources(inputs) {
         });
       }
     } else {
+      if (!input.endsWith(".chson.json")) {
+        throw new Error(`Expected a .chson.json file: ${input}`);
+      }
       const parentDirName = path.basename(path.dirname(input));
       sources.push({
         filePath: input,
@@ -125,32 +145,45 @@ function parseRegistryInitArgs(args) {
   let targetBase = "chson-files";
   let namespace = "@chson";
   let homepage = "https://chson.dev";
+  let packs = "none";
+  let failOnCollision = false;
   const inputs = [];
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
 
     if (arg === "--out") {
-      outputDir = args[i + 1];
+      outputDir = requireFlagValue(args, i, "--out");
       i += 1;
       continue;
     }
 
     if (arg === "--target-base") {
-      targetBase = args[i + 1];
+      targetBase = requireFlagValue(args, i, "--target-base");
       i += 1;
       continue;
     }
 
     if (arg === "--namespace") {
-      namespace = args[i + 1];
+      namespace = requireFlagValue(args, i, "--namespace");
       i += 1;
       continue;
     }
 
     if (arg === "--homepage") {
-      homepage = args[i + 1];
+      homepage = requireFlagValue(args, i, "--homepage");
       i += 1;
+      continue;
+    }
+
+    if (arg === "--packs") {
+      packs = requireFlagValue(args, i, "--packs");
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--fail-on-collision") {
+      failOnCollision = true;
       continue;
     }
 
@@ -159,6 +192,10 @@ function parseRegistryInitArgs(args) {
 
   if (!namespace.startsWith("@")) {
     throw new Error("--namespace must start with '@' (example: @chson)");
+  }
+
+  if (packs !== "none" && packs !== "by-directory") {
+    throw new Error("--packs must be one of: none, by-directory");
   }
 
   if (!outputDir || !targetBase || !homepage || inputs.length === 0) {
@@ -170,37 +207,100 @@ function parseRegistryInitArgs(args) {
     targetBase,
     namespace,
     homepage,
+    packs,
+    failOnCollision,
     inputs,
   };
 }
 
-function buildRegistryItems(sources, targetBase) {
-  const items = [];
+function buildRegistryItems(sources, { targetBase, packs, failOnCollision }) {
+  const fileItems = [];
   const seenNames = new Set();
 
   const sortedSources = [...sources].sort((left, right) =>
     left.relativePath.localeCompare(right.relativePath),
   );
 
-  for (const source of sortedSources) {
+  const prepared = sortedSources.map((source) => {
     const relativeInputPath = source.relativePath;
     const withoutExt = stripChsonExtension(relativeInputPath);
     const slugBase =
       toKebabCase(withoutExt.replaceAll("/", "-")) || "chson-item";
-    const itemName = uniqueSlug(slugBase, seenNames);
+    return {
+      source,
+      relativeInputPath,
+      withoutExt,
+      slugBase,
+    };
+  });
 
-    const chson = parseJsonFile(source.filePath);
+  if (failOnCollision) {
+    const collisions = new Map();
+    for (const entry of prepared) {
+      if (!collisions.has(entry.slugBase)) {
+        collisions.set(entry.slugBase, []);
+      }
+      collisions.get(entry.slugBase).push(entry.source.filePath);
+    }
+
+    const conflictLines = [];
+    for (const [slug, filePaths] of collisions.entries()) {
+      if (filePaths.length > 1) {
+        conflictLines.push(`- ${slug}: ${filePaths.join(", ")}`);
+      }
+    }
+
+    if (conflictLines.length > 0) {
+      throw new Error(
+        `Item name collisions detected (rerun without --fail-on-collision to auto-suffix):\n${conflictLines.join("\n")}`,
+      );
+    }
+  }
+
+  const itemsByGroup = new Map();
+
+  for (const entry of prepared) {
+    const itemName = uniqueSlug(entry.slugBase, seenNames);
+
+    const chson = parseJsonFile(entry.source.filePath);
     const title = chson.title || itemName;
     const description = chson.description || `Installs ${title} ChSON file.`;
+    const tags = Array.isArray(chson.tags)
+      ? chson.tags.filter((tag) => typeof tag === "string" && tag.length > 0)
+      : [];
 
-    const sourcePath = `registry/default/${withoutExt}.chson.json`;
-    const targetPath = `~/${toPosixPath(path.join(targetBase, `${withoutExt}.chson.json`))}`;
+    const groupKey = path.posix.dirname(entry.withoutExt);
+    if (!itemsByGroup.has(groupKey)) {
+      itemsByGroup.set(groupKey, []);
+    }
+    itemsByGroup.get(groupKey).push(itemName);
 
-    items.push({
+    const sourcePath = `registry/default/${entry.withoutExt}.chson.json`;
+    const targetPath = `~/${toPosixPath(path.join(targetBase, `${entry.withoutExt}.chson.json`))}`;
+
+    const categories = [];
+    if (chson.documentType) {
+      categories.push(chson.documentType);
+    }
+    const productCategory = entry.withoutExt.split("/")[0];
+    if (productCategory) {
+      categories.push(productCategory);
+    }
+
+    fileItems.push({
       name: itemName,
       type: "registry:item",
       title,
       description,
+      categories: Array.from(new Set(categories)),
+      keywords: Array.from(new Set(tags)),
+      meta: {
+        publicationDate: chson.publicationDate,
+        retrievalDirection: chson.retrievalDirection,
+        version: chson.version,
+        homepage: chson.homepage,
+        documentType: chson.documentType,
+      },
       files: [
         {
           path: sourcePath,
@@ -209,19 +309,62 @@ function buildRegistryItems(sources, targetBase) {
         },
       ],
       _meta: {
-        inputFilePath: source.filePath,
+        inputFilePath: entry.source.filePath,
         sourcePath,
       },
     });
   }
 
-  return items;
+  const packItems = [];
+  if (packs === "by-directory") {
+    const groups = [...itemsByGroup.entries()].sort(([left], [right]) =>
+      left.localeCompare(right),
+    );
+
+    for (const [groupKey, groupItems] of groups) {
+      if (groupItems.length < 2) {
+        continue;
+      }
+
+      const basePackSlug = `${toKebabCase(groupKey.replaceAll("/", "-")) || "root"}-pack`;
+      const packName = uniqueSlug(basePackSlug, seenNames);
+      const groupLabel =
+        groupKey === "." ? "Root" : titleCase(groupKey.replaceAll("/", " "));
+
+      packItems.push({
+        name: packName,
+        type: "registry:item",
+        title: `${groupLabel} Pack`,
+        description: `Installs ${groupItems.length} ChSON files from ${groupKey === "." ? "the root group" : groupKey}.`,
+        categories: ["pack"],
+        meta: {
+          packStrategy: "by-directory",
+          group: groupKey,
+          itemCount: groupItems.length,
+        },
+        registryDependencies: [...groupItems].sort((left, right) =>
+          left.localeCompare(right),
+        ),
+      });
+    }
+  }
+
+  return {
+    items: [...fileItems, ...packItems],
+    stats: {
+      files: fileItems.length,
+      packs: packItems.length,
+    },
+  };
 }
 
 function writeRegistrySource({ outputDir, namespace, homepage, items }) {
   fs.mkdirSync(outputDir, { recursive: true });
 
   for (const item of items) {
+    if (!item._meta) {
+      continue;
+    }
     const absoluteSourcePath = path.join(outputDir, item._meta.sourcePath);
     fs.mkdirSync(path.dirname(absoluteSourcePath), { recursive: true });
     fs.copyFileSync(item._meta.inputFilePath, absoluteSourcePath);
@@ -246,14 +389,28 @@ function writeRegistrySource({ outputDir, namespace, homepage, items }) {
 }
 
 function initRegistry(args) {
-  const { outputDir, targetBase, namespace, homepage, inputs } =
-    parseRegistryInitArgs(args);
+  const {
+    outputDir,
+    targetBase,
+    namespace,
+    homepage,
+    packs,
+    failOnCollision,
+    inputs,
+  } = parseRegistryInitArgs(args);
   const sources = collectRegistrySources(inputs);
-  const items = buildRegistryItems(sources, targetBase);
+  const { items, stats } = buildRegistryItems(sources, {
+    targetBase,
+    packs,
+    failOnCollision,
+  });
   writeRegistrySource({ outputDir, namespace, homepage, items });
 
   console.log(`Created registry source in ${outputDir}`);
   console.log(`Generated ${items.length} items`);
+  if (stats.packs > 0) {
+    console.log(`Generated ${stats.packs} pack items`);
+  }
 }
 
 function escapeMarkdown(text) {

--- a/research/registry-distribution-notes.md
+++ b/research/registry-distribution-notes.md
@@ -23,6 +23,9 @@ This document tracks decisions for distributing ChSON files through shadcn regis
   - `registry/default/**` copied `.chson.json` files
 - Generated item type: `registry:item`
 - Generated file type: `registry:file`
+- Added optional flags:
+  - `--packs by-directory` to emit aggregate pack items via `registryDependencies`
+  - `--fail-on-collision` to fail on slug collisions instead of auto-suffixing
 
 ## Prototype strategy
 
@@ -41,19 +44,27 @@ This document tracks decisions for distributing ChSON files through shadcn regis
 
 Current behavior derives item names from relative file paths (example: `git/core.chson.json` -> `git-core`).
 
+Current guardrail:
+
+- `--fail-on-collision` can now enforce strict naming for CI/publisher workflows.
+
 Questions:
 
 - Should we support explicit item names in source metadata?
-- Should the generator fail on collisions instead of suffixing (`-2`, `-3`)?
+- Should strict collision mode become default in a future major version?
 
 ## 2) Bundles / packs
 
-Current generator creates one item per file.
+Current generator creates one item per file, with optional directory packs.
+
+Current behavior:
+
+- `--packs by-directory` emits pack items (example: `git-pack`) that depend on per-file items.
 
 Questions:
 
-- Should we generate optional pack items (example: `starter-pack`) using `registryDependencies`?
-- If yes, should packs be inferred by directory, tags, or explicit config?
+- Should we also support explicit/custom packs (not only inferred by directory)?
+- Should we support nested pack composition and top-level starter packs?
 
 ## 3) Versioning strategy
 
@@ -74,11 +85,15 @@ Questions:
 
 ## 5) Rich metadata mapping
 
-Current generator maps title/description directly and copies the file.
+Current generator maps title/description and also lifts selected ChSON fields:
+
+- `tags` -> `keywords`
+- `documentType` + first path segment -> `categories`
+- `publicationDate`, `retrievalDirection`, `version`, `homepage`, `documentType` -> `meta`
 
 Questions:
 
-- Should we surface ChSON fields (`tags`, `publicationDate`, `retrievalDirection`) into `meta`/`categories` in registry items?
+- Do we want a configurable metadata mapping (field allow/deny list)?
 
 ## Review Triggers
 

--- a/research/registry-improvements-plan.md
+++ b/research/registry-improvements-plan.md
@@ -1,0 +1,94 @@
+# Registry Improvements Plan
+
+This plan captures the next improvements for ChSON registry distribution after adding `--packs by-directory`, collision controls, and metadata mapping.
+
+## Goals
+
+- Keep registry publishing simple for maintainers.
+- Make installed item names predictable and stable.
+- Support higher-level bundles without breaking single-file installs.
+- Add explicit versioning guidance for long-term compatibility.
+
+## Phase 1: Explicit Naming and Pack Config
+
+### 1.1 Explicit item naming
+
+- Add optional config file support for item name overrides.
+- Validate uniqueness before generation.
+- Keep path-derived names as fallback.
+
+Deliverables:
+
+- CLI flag to load config (for example `--config registry.config.json`).
+- Config schema docs and examples.
+- Error messages listing conflicting names and source files.
+
+### 1.2 Custom packs
+
+- Support user-defined pack items in config (not only directory-inferred packs).
+- Allow packs to reference explicit items by name.
+- Keep inferred packs available with `--packs by-directory`.
+
+Deliverables:
+
+- Config-driven `registryDependencies` generation.
+- Validation to ensure pack dependencies exist.
+- Docs for authoring starter packs.
+
+## Phase 2: Versioned Registry Output
+
+### 2.1 Versioned routing mode
+
+- Add CLI option to emit versioned paths (for example `/r/v1/{name}.json`).
+- Keep unversioned output as default for backwards compatibility.
+
+Deliverables:
+
+- Generation mode for versioned output.
+- Docs on migration and deprecation policy.
+- CI check to validate both unversioned and versioned payloads.
+
+### 2.2 Compatibility policy
+
+- Define when item names can change and how to preserve aliases.
+- Document breaking vs non-breaking changes.
+
+Deliverables:
+
+- Registry versioning guidelines in docs.
+- Internal decision record for release policy.
+
+## Phase 3: Metadata Mapping Controls
+
+### 3.1 Configurable mapping
+
+- Allow include/exclude lists for mapped fields (`keywords`, `categories`, `meta`).
+- Keep sensible defaults that work without config.
+
+Deliverables:
+
+- Mapping config options and validation.
+- Public docs with examples for strict/minimal metadata output.
+
+### 3.2 Quality checks
+
+- Extend checks to verify mapped metadata shape.
+- Ensure dependencies and metadata stay consistent after regeneration.
+
+Deliverables:
+
+- Stronger `registry:check` assertions.
+- CI coverage for representative sample items.
+
+## Suggested Order
+
+1. Explicit naming + custom packs
+2. Versioned registry output
+3. Metadata mapping controls
+
+## Verification Checklist
+
+- Run `npm run validate` from repo root.
+- Run `npm --prefix examples/chson-shadcn-registry run registry:check`.
+- Validate consumer install flow with one single item and one pack item.
+- Confirm docs match final CLI flags and defaults.


### PR DESCRIPTION
## Summary
- extend `chson registry init` with `--packs by-directory` and `--fail-on-collision`, plus stricter flag/input validation
- enrich generated registry items with mapped ChSON metadata (`categories`, `keywords`, `meta`) and generate aggregate pack items (for example `git-pack`) via `registryDependencies`
- update registry docs/examples and add stronger prototype checks for dependency integrity, plus a follow-up roadmap in `research/registry-improvements-plan.md`

## Verification
- npm run validate
- npm --prefix examples/chson-shadcn-registry run registry:check