### PR TITLE
Add sitemap and robots routes

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -5,6 +5,7 @@ import { QueryProvider } from 'providers/query-provider';
 import { ThemeProvider } from 'providers/theme-provider';
 
 export const metadata: Metadata = {
+  metadataBase: new URL('https://chson.dev'),
   title: 'ChSON',
   description:
     'A JSON format for writing software cheatsheets. Write once, render anywhere.',

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: 'https://chson.dev/sitemap.xml',
+  };
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,0 +1,81 @@
+import fs from 'node:fs';
+import type { MetadataRoute } from 'next';
+import { getAllCheatsheets } from 'lib/cheatsheets';
+import { source } from 'lib/source';
+
+const siteUrl = 'https://chson.dev';
+const buildTimestamp = process.env.VERCEL_GIT_COMMIT_DATE
+  ? new Date(process.env.VERCEL_GIT_COMMIT_DATE)
+  : new Date();
+
+type DocsParam = { slug?: string[] };
+
+function getDocsPath(param: DocsParam): string {
+  if (!param.slug || param.slug.length === 0) {
+    return '/docs';
+  }
+
+  const slug = param.slug.map((segment) => encodeURIComponent(segment)).join('/');
+  return `/docs/${slug}`;
+}
+
+function getDocsEntries(): MetadataRoute.Sitemap {
+  const params = source.generateParams() as DocsParam[];
+
+  return params
+    .map((param) => getDocsPath(param))
+    .filter((urlPath) => urlPath !== '/docs')
+    .map((urlPath) => ({
+      url: `${siteUrl}${urlPath}`,
+      lastModified: buildTimestamp,
+      changeFrequency: 'weekly' as const,
+      priority: 0.8,
+    }));
+}
+
+function getCheatsheetEntries(): MetadataRoute.Sitemap {
+  return getAllCheatsheets().map((ref) => {
+    let lastModified = buildTimestamp;
+
+    try {
+      lastModified = fs.statSync(ref.filePath).mtime;
+    } catch {
+      lastModified = buildTimestamp;
+    }
+
+    return {
+      url: `${siteUrl}/cheatsheets/${encodeURIComponent(ref.product)}/${encodeURIComponent(ref.name)}`,
+      lastModified,
+      changeFrequency: 'weekly' as const,
+      priority: 0.7,
+    };
+  });
+}
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const staticEntries: MetadataRoute.Sitemap = [
+    {
+      url: `${siteUrl}/`,
+      lastModified: buildTimestamp,
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${siteUrl}/docs`,
+      lastModified: buildTimestamp,
+      changeFrequency: 'weekly',
+      priority: 0.9,
+    },
+    {
+      url: `${siteUrl}/use-cases`,
+      lastModified: buildTimestamp,
+      changeFrequency: 'weekly',
+      priority: 0.9,
+    },
+  ];
+
+  const entries = [...staticEntries, ...getDocsEntries(), ...getCheatsheetEntries()];
+  const deduped = new Map(entries.map((entry) => [entry.url, entry]));
+
+  return Array.from(deduped.values());
+}


### PR DESCRIPTION
## Summary
- add canonical metadataBase so URLs are stable for sitemap and robots
- generate sitemap.xml covering static pages, docs routes, and cheatsheet detail pages
- expose robots.txt that points crawlers to the sitemap